### PR TITLE
fixed some logic errors between difficulties and various other logic changes

### DIFF
--- a/AP_Randomizer/apworld/locations.py
+++ b/AP_Randomizer/apworld/locations.py
@@ -95,7 +95,7 @@ location_table = {
         region="Keep Main",),
     "Sansa Keep - Lonely Throne": PseudoregaliaLocationData(
         code=2365810023,
-        region="Keep Path To Throne",),
+        region="Keep Main",),
     "Sansa Keep - Near Theatre": PseudoregaliaLocationData(
         code=2365810024,
         region="Keep Main",),

--- a/AP_Randomizer/apworld/regions.py
+++ b/AP_Randomizer/apworld/regions.py
@@ -70,7 +70,6 @@ region_table: Dict[str, List[str]] = {
     "Keep Main":
         ["Keep Locked Room",
          "Keep Sunsetter",
-         "Keep Path To Throne",
          "Keep => Underbelly",
          "Theatre Outside Scythe Corridor",],
     "Keep Locked Room":
@@ -80,8 +79,6 @@ region_table: Dict[str, List[str]] = {
     "Keep => Underbelly":
         ["Keep Main",
          "Underbelly => Keep"],
-    "Keep Path To Throne":
-        [],
 
     "Empty Bailey":
         ["Castle Main",

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -1,7 +1,7 @@
 from BaseClasses import CollectionState
 from typing import Dict, Callable, TYPE_CHECKING
 from worlds.generic.Rules import set_rule
-from .constants.difficulties import NORMAL
+from .constants.difficulties import NORMAL, EXPERT, LUNATIC
 
 if TYPE_CHECKING:
     from . import PseudoregaliaWorld
@@ -80,6 +80,17 @@ class PseudoregaliaRulesHelpers:
             "Tower Remains - Atop The Tower": lambda state: True,
         }
 
+        logic_level = world.options.logic_level.value
+        if logic_level == NORMAL:
+            self.required_small_keys = 7
+
+        if bool(world.options.obscure_logic) or logic_level in {EXPERT, LUNATIC}:
+            self.knows_obscure = lambda state: True
+            self.can_attack = lambda state: self.has_breaker(state) or self.has_plunge(state)
+        else:
+            self.knows_obscure = lambda state: False
+            self.can_attack = lambda state: self.has_breaker(state)
+
     def has_breaker(self, state) -> bool:
         return state.has_any({"Dream Breaker", "Progressive Dream Breaker"}, self.player)
 
@@ -149,16 +160,6 @@ class PseudoregaliaRulesHelpers:
         world = self.world
         multiworld = self.world.multiworld
         split_kicks = bool(world.options.split_sun_greaves)
-        if bool(world.options.obscure_logic):
-            self.knows_obscure = lambda state: True
-            self.can_attack = lambda state: self.has_breaker(state) or self.has_plunge(state)
-        else:
-            self.knows_obscure = lambda state: False
-            self.can_attack = lambda state: self.has_breaker(state)
-
-        logic_level = world.options.logic_level.value
-        if logic_level == NORMAL:
-            self.required_small_keys = 7
 
         for name, rule in self.region_rules.items():
             entrance = multiworld.get_entrance(name, self.player)

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -25,7 +25,7 @@ class PseudoregaliaRulesHelpers:
             "Empty Bailey -> Theatre Pillar": lambda state: True,
             "Empty Bailey -> Tower Remains": lambda state:
                 self.has_gem(state)
-                or state.has_all({"Slide", "Sunsetter"}, self.player)
+                or self.has_slide(state) and self.has_plunge(state)
                 or self.get_kicks(state, 1),
             "Tower Remains -> Underbelly Little Guy": lambda state:
                 self.has_plunge(state),
@@ -52,7 +52,7 @@ class PseudoregaliaRulesHelpers:
                 self.has_slide(state),
             "Empty Bailey - Center Steeple": lambda state:
                 self.get_kicks(state, 3)
-                or state.has_all({"Sunsetter", "Slide"}, self.player),
+                or self.has_slide(state) and self.has_plunge(state),
             "Empty Bailey - Guarded Hand": lambda state:
                 self.has_plunge(state)
                 or self.has_gem(state)

--- a/AP_Randomizer/apworld/rules_expert.py
+++ b/AP_Randomizer/apworld/rules_expert.py
@@ -35,7 +35,6 @@ class PseudoregaliaExpertRules(PseudoregaliaRulesHelpers):
                 or self.kick_or_plunge(state, 1)
                 or self.has_gem(state)
                 or self.has_slide(state),
-            # "Dungeon Escape Upper -> Theatre Outside Scythe Corridor": lambda state: True,
             # "Castle Main -> Dungeon => Castle": lambda state: True,
             # "Castle Main -> Keep Main": lambda state: True,
             # "Castle Main -> Empty Bailey": lambda state: True,
@@ -50,8 +49,11 @@ class PseudoregaliaExpertRules(PseudoregaliaRulesHelpers):
                 or self.has_slide(state)
                 or self.kick_or_plunge(state, 2),
             # "Castle Spiral Climb -> Castle Main": lambda state: True,
-            # "Castle Spiral Climb -> Castle High Climb": lambda state: True,
-                # Anything that gets you into spiral climb can get from there to high climb
+            "Castle Spiral Climb -> Castle High Climb": lambda state:
+                self.has_gem(state)
+                or self.has_slide(state)
+                or self.get_kicks(state, 2)
+                or self.can_attack(state) and self.get_kicks(state, 1),
             "Castle Spiral Climb -> Castle By Scythe Corridor": lambda state:
                 self.has_gem(state)
                 or self.kick_or_plunge(state, 4),
@@ -80,7 +82,8 @@ class PseudoregaliaExpertRules(PseudoregaliaRulesHelpers):
                 self.has_slide(state),
             "Library Main -> Library Top": lambda state:
                 self.has_gem(state)
-                or self.kick_or_plunge(state, 2)
+                or self.has_plunge(state)
+                or self.get_kicks(state, 2)
                 or self.has_slide(state),
             "Library Greaves -> Library Top": lambda state:
                 self.has_gem(state)
@@ -101,17 +104,16 @@ class PseudoregaliaExpertRules(PseudoregaliaRulesHelpers):
                 or self.get_kicks(state, 1)
                 or self.has_slide(state)
                 or self.can_bounce(state),
-            "Keep Main -> Keep Path To Throne": lambda state:
-                self.has_breaker(state),
             # "Keep Locked Room -> Keep Sunsetter": lambda state: True,
             # "Keep => Underbelly -> Keep Main": lambda state: True,
             # "Keep => Underbelly -> Underbelly => Keep": lambda state: True,
-            # "Underbelly => Dungeon -> Dungeon Escape Lower": lambda state: True,
+            "Underbelly => Dungeon -> Dungeon Escape Lower": lambda state:
+                self.navigate_darkrooms(state),
             # "Underbelly => Dungeon -> Underbelly Light Pillar": lambda state: True,
             "Underbelly => Dungeon -> Underbelly Ascendant Light": lambda state:
-                self.has_breaker(state)
+                self.can_attack(state)
                 or self.has_gem(state)
-                or self.kick_or_plunge(state, 2)
+                or self.get_kicks(state, 2)
                 or self.get_kicks(state, 1) and self.has_slide(state),
             # "Underbelly Light Pillar -> Underbelly Main Upper": lambda state: True,
             "Underbelly Light Pillar -> Underbelly => Dungeon": lambda state:
@@ -131,7 +133,8 @@ class PseudoregaliaExpertRules(PseudoregaliaRulesHelpers):
                     self.has_gem(state)
                     or self.get_kicks(state, 1)
                     or self.has_slide(state)),
-            # "Underbelly Ascendant Light -> Underbelly Light Pillar": lambda state: True,
+            "Underbelly Ascendant Light -> Underbelly Light Pillar": lambda state:
+                self.has_breaker(state),
             "Underbelly Ascendant Light -> Underbelly => Dungeon": lambda state:
                 self.can_bounce(state)
                 or self.has_gem(state)
@@ -139,12 +142,7 @@ class PseudoregaliaExpertRules(PseudoregaliaRulesHelpers):
                 or self.has_slide(state) and self.get_kicks(state, 1),
             # "Underbelly Main Lower -> Underbelly Little Guy": lambda state: True,
             "Underbelly Main Lower -> Underbelly Hole": lambda state:
-                self.has_plunge(state)
-                and (
-                    self.get_kicks(state, 1)
-                    or self.has_gem(state)
-                    or self.has_slide(state)
-                    or self.can_attack(state)),
+                self.has_plunge(state),
             "Underbelly Main Lower -> Underbelly By Heliacal": lambda state:
                 self.has_slide(state),
             "Underbelly Main Lower -> Underbelly Main Upper": lambda state:
@@ -175,11 +173,19 @@ class PseudoregaliaExpertRules(PseudoregaliaRulesHelpers):
                 and (
                     state.has("Ascendant Light", self.player)
                     or self.has_gem(state)
-                    or self.has_plunge(state) and self.get_kicks(state, 3)),
+                    or self.has_plunge(state) and self.get_kicks(state, 3)
+                    or self.has_slide(state) and self.get_kicks(state, 2)),
             "Underbelly By Heliacal -> Underbelly Main Upper": lambda state:
-                self.can_attack(state)
-                or self.has_gem(state)
-                or self.get_kicks(state, 2),
+                self.has_plunge(state)
+                or self.has_breaker(state)
+                and (
+                    self.has_slide(state)
+                    or self.has_gem(state)
+                    or self.get_kicks(state, 1))
+                or self.has_slide(state)
+                and (
+                    self.has_gem(state)
+                    or self.get_kicks(state, 2)),
             # "Underbelly Little Guy -> Empty Bailey": lambda state: True,
             # "Underbelly Little Guy -> Underbelly Main Lower": lambda state: True,
             # "Underbelly => Keep -> Keep => Underbelly": lambda state: True,
@@ -276,7 +282,7 @@ class PseudoregaliaExpertRules(PseudoregaliaRulesHelpers):
             "Listless Library - Sun Greaves 3": lambda state:
                 self.can_attack(state),
             "Listless Library - Upper Back": lambda state:
-                (self.has_breaker(state) or self.knows_obscure(state) and self.has_plunge(state))
+                self.can_attack(state)
                 and (
                     self.has_gem(state)
                     or self.kick_or_plunge(state, 2)
@@ -291,21 +297,26 @@ class PseudoregaliaExpertRules(PseudoregaliaRulesHelpers):
                 or self.has_slide(state) and self.kick_or_plunge(state, 1),
             "Sansa Keep - Near Theatre": lambda state:
                 self.kick_or_plunge(state, 1)
-                or self.has_gem(state),
+                or self.has_gem(state)
+                or self.has_slide(state),
             # "Sansa Keep - Alcove Near Locked Door": lambda state: True,
             "Sansa Keep - Levers Room": lambda state:
                 self.can_attack(state),
             "Sansa Keep - Sunsetter": lambda state:
                 self.can_attack(state),
             "Sansa Keep - Strikebreak": lambda state:
-                self.can_attack(state) and self.has_slide(state)
-                or self.can_strikebreak(state) and self.has_gem(state)
-                or self.can_strikebreak(state) and self.kick_or_plunge(state, 1),
+                self.has_breaker(state) and self.has_slide(state)
+                or self.can_strikebreak(state)
+                and (
+                    self.has_gem(state)
+                    or self.kick_or_plunge(state, 1)),
             "Sansa Keep - Lonely Throne": lambda state:
-                self.has_gem(state)
-                or self.has_plunge(state) and self.get_kicks(state, 4)
-                or state.has("Ascendant Light", self.player) and self.kick_or_plunge(state, 3)
-                or self.has_slide(state) and self.get_kicks(state, 3),
+                self.has_breaker(state)
+                and (
+                    self.has_gem(state)
+                    or self.has_plunge(state) and self.get_kicks(state, 4)
+                    or state.has("Ascendant Light", self.player) and self.kick_or_plunge(state, 3)
+                    or self.has_slide(state) and self.get_kicks(state, 3)),
             # "The Underbelly - Ascendant Light": lambda state: True,
             "The Underbelly - Rafters Near Keep": lambda state:
                 self.kick_or_plunge(state, 1)
@@ -317,7 +328,7 @@ class PseudoregaliaExpertRules(PseudoregaliaRulesHelpers):
             "The Underbelly - Main Room": lambda state:
                 self.has_plunge(state)
                 or self.has_gem(state)
-                or self.get_kicks(state, 2)
+                or self.get_kicks(state, 1)
                 or self.has_slide(state),
             "The Underbelly - Alcove Near Light": lambda state:
                 self.can_attack(state)

--- a/AP_Randomizer/apworld/rules_hard.py
+++ b/AP_Randomizer/apworld/rules_hard.py
@@ -33,13 +33,11 @@ class PseudoregaliaHardRules(PseudoregaliaRulesHelpers):
                 self.can_bounce(state)
                 or self.kick_or_plunge(state, 1)
                 or self.has_gem(state),
-            # "Dungeon Escape Upper -> Theatre Outside Scythe Corridor": lambda state: True,
             # "Castle Main -> Dungeon => Castle": lambda state: True,
             # "Castle Main -> Keep Main": lambda state: True,
             # "Castle Main -> Empty Bailey": lambda state: True,
             "Castle Main -> Library Main": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state) and self.can_attack(state),
+                self.can_attack(state),
             "Castle Main -> Theatre Pillar": lambda state:
                 self.has_gem(state)
                 or self.kick_or_plunge(state, 1),
@@ -51,9 +49,7 @@ class PseudoregaliaHardRules(PseudoregaliaRulesHelpers):
             "Castle Spiral Climb -> Castle High Climb": lambda state:
                 self.has_gem(state)
                 or self.kick_or_plunge(state, 3)
-                or self.has_breaker(state) and self.get_kicks(state, 1)
-                or self.knows_obscure(state) and self.has_plunge(state) and self.get_kicks(state, 1)
-                or self.knows_obscure(state) and self.can_attack(state) and self.can_slidejump(state),
+                or self.can_attack(state) and self.get_kicks(state, 1),
             "Castle Spiral Climb -> Castle By Scythe Corridor": lambda state:
                 self.has_gem(state),
             "Castle By Scythe Corridor -> Castle Spiral Climb": lambda state:
@@ -100,19 +96,18 @@ class PseudoregaliaHardRules(PseudoregaliaRulesHelpers):
                 or self.get_kicks(state, 1)
                 or self.can_bounce(state)
                 or self.can_slidejump(state),
-            "Keep Main -> Keep Path To Throne": lambda state:
-                self.has_breaker(state),
             # "Keep Locked Room -> Keep Sunsetter": lambda state: True,
             # "Keep => Underbelly -> Keep Main": lambda state: True,
             # "Keep => Underbelly -> Underbelly => Keep": lambda state: True,
-            # "Underbelly => Dungeon -> Dungeon Escape Lower": lambda state: True,
+            "Underbelly => Dungeon -> Dungeon Escape Lower": lambda state:
+                self.navigate_darkrooms(state),
             # "Underbelly => Dungeon -> Underbelly Light Pillar": lambda state: True,
             "Underbelly => Dungeon -> Underbelly Ascendant Light": lambda state:
                 self.can_bounce(state)
                 or self.has_gem(state)
                 or self.kick_or_plunge(state, 2)
                 or self.get_kicks(state, 1) and self.can_slidejump(state)
-                or self.knows_obscure(state) and self.has_breaker(state),
+                or self.knows_obscure(state) and self.can_attack(state),
             # "Underbelly Light Pillar -> Underbelly Main Upper": lambda state: True,
             "Underbelly Light Pillar -> Underbelly => Dungeon": lambda state:
                 self.can_bounce(state)
@@ -128,13 +123,13 @@ class PseudoregaliaHardRules(PseudoregaliaRulesHelpers):
                     self.has_gem(state)
                     or self.get_kicks(state, 1)
                     or self.can_slidejump(state)),
-            # "Underbelly Ascendant Light -> Underbelly Light Pillar": lambda state: True,
+            "Underbelly Ascendant Light -> Underbelly Light Pillar": lambda state:
+                self.has_breaker(state),
             "Underbelly Ascendant Light -> Underbelly => Dungeon": lambda state:
                 self.can_bounce(state)
                 or self.has_gem(state)
                 or self.kick_or_plunge(state, 2)
-                or self.get_kicks(state, 1) and self.can_slidejump(state)
-                or self.knows_obscure(state) and self.has_slide(state) and self.get_kicks(state, 1),
+                or self.get_kicks(state, 1) and self.can_slidejump(state),
             # "Underbelly Main Lower -> Underbelly Little Guy": lambda state: True,
             "Underbelly Main Lower -> Underbelly Hole": lambda state:
                 self.has_plunge(state)
@@ -171,11 +166,10 @@ class PseudoregaliaHardRules(PseudoregaliaRulesHelpers):
                     or self.can_slidejump(state) and self.get_kicks(state, 3)),
             "Underbelly By Heliacal -> Underbelly Main Upper": lambda state:
                 self.has_breaker(state) and self.has_plunge(state)
-                or self.knows_obscure(state)
+                or self.knows_obscure(state) and self.has_plunge(state)
                 and (
-                    self.has_plunge(state)
-                    or self.has_breaker(state)
-                    or self.get_kicks(state, 4)),
+                    self.has_gem(state)
+                    or self.get_kicks(state, 1)),
             # "Underbelly Little Guy -> Empty Bailey": lambda state: True,
             # "Underbelly Little Guy -> Underbelly Main Lower": lambda state: True,
             # "Underbelly => Keep -> Keep => Underbelly": lambda state: True,
@@ -232,8 +226,7 @@ class PseudoregaliaHardRules(PseudoregaliaRulesHelpers):
             "Castle Sansa - Balcony": lambda state:
                 self.has_gem(state)
                 or self.kick_or_plunge(state, 3)
-                or self.has_slide(state) and self.has_plunge(state)
-                or self.has_slide(state) and self.get_kicks(state, 1) and self.has_breaker(state),
+                or self.can_slidejump(state),
             "Castle Sansa - Corner Corridor": lambda state:
                 self.has_gem(state)
                 or self.get_kicks(state, 3),
@@ -245,6 +238,7 @@ class PseudoregaliaHardRules(PseudoregaliaRulesHelpers):
                 or self.knows_obscure(state) and self.has_plunge(state),
             "Castle Sansa - Alcove Near Scythe Corridor": lambda state:
                 self.has_gem(state)
+                or self.get_kicks(state, 4)
                 or self.get_kicks(state, 2) and self.has_plunge(state),
             "Castle Sansa - Near Theatre Front": lambda state:
                 self.has_gem(state)
@@ -257,19 +251,15 @@ class PseudoregaliaHardRules(PseudoregaliaRulesHelpers):
                 or self.has_breaker(state) and self.get_kicks(state, 1)
                 or self.knows_obscure(state) and self.has_plunge(state) and self.get_kicks(state, 1),
             "Listless Library - Sun Greaves": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state) and self.has_plunge(state),
+                self.can_attack(state),
             "Listless Library - Sun Greaves 1": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state) and self.has_plunge(state),
+                self.can_attack(state),
             "Listless Library - Sun Greaves 2": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state) and self.has_plunge(state),
+                self.can_attack(state),
             "Listless Library - Sun Greaves 3": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state) and self.has_plunge(state),
+                self.can_attack(state),
             "Listless Library - Upper Back": lambda state:
-                (self.has_breaker(state) or self.knows_obscure(state) and self.has_plunge(state))
+                self.can_attack(state)
                 and (
                     self.has_gem(state)
                     or self.kick_or_plunge(state, 2)),
@@ -290,24 +280,23 @@ class PseudoregaliaHardRules(PseudoregaliaRulesHelpers):
             "Sansa Keep - Sunsetter": lambda state:
                 self.can_attack(state),
             "Sansa Keep - Strikebreak": lambda state:
-                (self.can_attack(state) and (self.has_slide(state) or self.can_strikebreak(state)))
+                self.has_breaker(state) and (self.has_slide(state) or self.can_strikebreak(state))
                 and (
                     self.has_gem(state)
-                    or self.kick_or_plunge(state, 1)),
+                    or self.get_kicks(state, 1)),
             "Sansa Keep - Lonely Throne": lambda state:
-                self.has_gem(state)
+                self.has_breaker(state) and self.has_gem(state)
                 and (
                     self.has_plunge(state)
                     or self.get_kicks(state, 2)
                     or self.get_kicks(state, 1) and state.has("Ascendant Light", self.player)
                     or self.get_kicks(state, 1) and self.knows_obscure(state))
-                or self.has_plunge(state) and self.get_kicks(state, 4)
-                or state.has("Ascendant Light", self.player) and self.get_kicks(state, 3),
+                or self.has_breaker(state) and self.has_plunge(state) and self.get_kicks(state, 4)
+                or self.can_bounce(state) and self.get_kicks(state, 3),
             # "The Underbelly - Ascendant Light": lambda state: True,
             "The Underbelly - Rafters Near Keep": lambda state:
                 self.kick_or_plunge(state, 1)
                 or self.has_gem(state)
-                or self.has_slide(state)
                 or self.can_bounce(state),
             "The Underbelly - Locked Door": lambda state:
                 self.has_small_keys(state),

--- a/AP_Randomizer/apworld/rules_lunatic.py
+++ b/AP_Randomizer/apworld/rules_lunatic.py
@@ -35,7 +35,6 @@ class PseudoregaliaLunaticRules(PseudoregaliaRulesHelpers):
                 or self.kick_or_plunge(state, 1)
                 or self.has_gem(state)
                 or self.has_slide(state),
-            # "Dungeon Escape Upper -> Theatre Outside Scythe Corridor": lambda state: True,
             # "Castle Main -> Dungeon => Castle": lambda state: True,
             # "Castle Main -> Keep Main": lambda state: True,
             # "Castle Main -> Empty Bailey": lambda state: True,
@@ -49,8 +48,12 @@ class PseudoregaliaLunaticRules(PseudoregaliaRulesHelpers):
                 self.has_gem(state)
                 or self.has_slide(state)
                 or self.kick_or_plunge(state, 2),
-            # "Castle Spiral Climb -> Castle High Climb": lambda state: True,
-                # Anything that gets you into spiral climb can get from there to high climb
+            # "Castle Spiral Climb -> Castle Main": lambda state: True,
+            "Castle Spiral Climb -> Castle High Climb": lambda state:
+                self.has_gem(state)
+                or self.has_slide(state)
+                or self.get_kicks(state, 2)
+                or self.can_attack(state) and self.get_kicks(state, 1),
             "Castle Spiral Climb -> Castle By Scythe Corridor": lambda state:
                 self.has_gem(state)
                 or self.get_kicks(state, 3),
@@ -79,7 +82,8 @@ class PseudoregaliaLunaticRules(PseudoregaliaRulesHelpers):
                 self.has_slide(state),
             "Library Main -> Library Top": lambda state:
                 self.has_gem(state)
-                or self.kick_or_plunge(state, 2)
+                or self.has_plunge(state)
+                or self.get_kicks(state, 2)
                 or self.has_slide(state),
             "Library Greaves -> Library Top": lambda state:
                 self.has_gem(state)
@@ -100,17 +104,16 @@ class PseudoregaliaLunaticRules(PseudoregaliaRulesHelpers):
                 or self.get_kicks(state, 1)
                 or self.has_slide(state)
                 or self.can_bounce(state),
-            "Keep Main -> Keep Path To Throne": lambda state:
-                self.has_breaker(state),
             # "Keep Locked Room -> Keep Sunsetter": lambda state: True,
             # "Keep => Underbelly -> Keep Main": lambda state: True,
             # "Keep => Underbelly -> Underbelly => Keep": lambda state: True,
-            # "Underbelly => Dungeon -> Dungeon Escape Lower": lambda state: True,
+            "Underbelly => Dungeon -> Dungeon Escape Lower": lambda state:
+                self.navigate_darkrooms(state),
             # "Underbelly => Dungeon -> Underbelly Light Pillar": lambda state: True,
             "Underbelly => Dungeon -> Underbelly Ascendant Light": lambda state:
-                self.has_breaker(state)
+                self.can_attack(state)
                 or self.has_gem(state)
-                or self.kick_or_plunge(state, 2)
+                or self.get_kicks(state, 2)
                 or self.get_kicks(state, 1) and self.has_slide(state),
             # "Underbelly Light Pillar -> Underbelly Main Upper": lambda state: True,
             "Underbelly Light Pillar -> Underbelly => Dungeon": lambda state:
@@ -130,7 +133,8 @@ class PseudoregaliaLunaticRules(PseudoregaliaRulesHelpers):
                     self.has_gem(state)
                     or self.get_kicks(state, 1)
                     or self.has_slide(state)),
-            # "Underbelly Ascendant Light -> Underbelly Light Pillar": lambda state: True,
+            "Underbelly Ascendant Light -> Underbelly Light Pillar": lambda state:
+                self.has_breaker(state),
             "Underbelly Ascendant Light -> Underbelly => Dungeon": lambda state:
                 self.can_bounce(state)
                 or self.has_gem(state)
@@ -138,12 +142,7 @@ class PseudoregaliaLunaticRules(PseudoregaliaRulesHelpers):
                 or self.has_slide(state) and self.get_kicks(state, 1),
             # "Underbelly Main Lower -> Underbelly Little Guy": lambda state: True,
             "Underbelly Main Lower -> Underbelly Hole": lambda state:
-                self.has_plunge(state)
-                and (
-                    self.get_kicks(state, 1)
-                    or self.has_gem(state)
-                    or self.has_slide(state)
-                    or self.can_attack(state)),
+                self.has_plunge(state),
             "Underbelly Main Lower -> Underbelly By Heliacal": lambda state:
                 self.has_slide(state),
             "Underbelly Main Lower -> Underbelly Main Upper": lambda state:
@@ -174,11 +173,19 @@ class PseudoregaliaLunaticRules(PseudoregaliaRulesHelpers):
                 and (
                     state.has("Ascendant Light", self.player)
                     or self.has_gem(state)
-                    or self.has_plunge(state) and self.get_kicks(state, 3)),
+                    or self.has_plunge(state) and self.get_kicks(state, 3)
+                    or self.has_slide(state) and self.get_kicks(state, 2)),
             "Underbelly By Heliacal -> Underbelly Main Upper": lambda state:
-                self.can_attack(state)
-                or self.has_gem(state)
-                or self.get_kicks(state, 2),
+                self.has_plunge(state)
+                or self.has_breaker(state)
+                and (
+                    self.has_slide(state)
+                    or self.has_gem(state)
+                    or self.get_kicks(state, 1))
+                or self.has_slide(state)
+                and (
+                    self.has_gem(state)
+                    or self.get_kicks(state, 2)),
             # "Underbelly Little Guy -> Empty Bailey": lambda state: True,
             # "Underbelly Little Guy -> Underbelly Main Lower": lambda state: True,
             # "Underbelly => Keep -> Keep => Underbelly": lambda state: True,
@@ -276,10 +283,11 @@ class PseudoregaliaLunaticRules(PseudoregaliaRulesHelpers):
             "Listless Library - Sun Greaves 3": lambda state:
                 self.can_attack(state),
             "Listless Library - Upper Back": lambda state:
-                (self.has_breaker(state) or self.knows_obscure(state) and self.has_plunge(state))
+                self.has_plunge(state)
+                or self.has_breaker(state)
                 and (
                     self.has_gem(state)
-                    or self.kick_or_plunge(state, 2)
+                    or self.get_kicks(state, 2)
                     or self.has_slide(state)),
             "Listless Library - Locked Door Across": lambda state:
                 self.has_gem(state)
@@ -291,25 +299,30 @@ class PseudoregaliaLunaticRules(PseudoregaliaRulesHelpers):
                 or self.has_slide(state) and self.kick_or_plunge(state, 1),
             "Sansa Keep - Near Theatre": lambda state:
                 self.kick_or_plunge(state, 1)
-                or self.has_gem(state),
+                or self.has_gem(state)
+                or self.has_slide(state),
             # "Sansa Keep - Alcove Near Locked Door": lambda state: True,
             # "Sansa Keep - Levers Room": lambda state: True,
             "Sansa Keep - Sunsetter": lambda state:
                 self.can_attack(state),
             "Sansa Keep - Strikebreak": lambda state:
-                self.can_attack(state) and self.has_slide(state)
-                or self.can_strikebreak(state) and self.has_gem(state)
-                or self.can_strikebreak(state) and self.kick_or_plunge(state, 1),
+                self.has_breaker(state) and self.has_slide(state)
+                or self.can_strikebreak(state)
+                and (
+                    self.has_gem(state)
+                    or self.kick_or_plunge(state, 1)),
             "Sansa Keep - Lonely Throne": lambda state:
-                self.has_gem(state)
-                or self.has_plunge(state) and self.get_kicks(state, 4)
-                or state.has("Ascendant Light", self.player) and self.kick_or_plunge(state, 3)
-                or self.has_slide(state) and self.kick_or_plunge(state, 3)
-                or (self.has_slide(state)
-                    and state.has("Ascendant Light", self.player)
+                self.has_breaker(state)
+                and (
+                    self.has_gem(state)
+                    or self.has_plunge(state) and self.get_kicks(state, 4)
+                    or state.has("Ascendant Light", self.player) and self.kick_or_plunge(state, 3)
+                    or self.has_slide(state) and self.kick_or_plunge(state, 3))
+                or self.has_slide(state)
+                    and self.can_bounce(state)
                     and self.get_kicks(state, 1)
                     and self.has_plunge(state)
-                    and self.can_soulcutter(state)),
+                    and self.can_soulcutter(state),
             # "The Underbelly - Ascendant Light": lambda state: True,
             "The Underbelly - Rafters Near Keep": lambda state:
                 self.kick_or_plunge(state, 1)
@@ -321,7 +334,7 @@ class PseudoregaliaLunaticRules(PseudoregaliaRulesHelpers):
             "The Underbelly - Main Room": lambda state:
                 self.has_plunge(state)
                 or self.has_gem(state)
-                or self.get_kicks(state, 2)
+                or self.get_kicks(state, 1)
                 or self.has_slide(state),
             "The Underbelly - Alcove Near Light": lambda state:
                 self.can_attack(state)

--- a/AP_Randomizer/apworld/rules_normal.py
+++ b/AP_Randomizer/apworld/rules_normal.py
@@ -33,13 +33,11 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 self.can_bounce(state)
                 or self.kick_or_plunge(state, 1)
                 or self.has_gem(state),
-            # "Dungeon Escape Upper -> Theatre Outside Scythe Corridor": lambda state: True,
             # "Castle Main -> Dungeon => Castle": lambda state: True,
             # "Castle Main -> Keep Main": lambda state: True,
             # "Castle Main -> Empty Bailey": lambda state: True,
             "Castle Main -> Library Main": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state) and self.can_attack(state),
+                self.can_attack(state),
             "Castle Main -> Theatre Pillar": lambda state:
                 self.has_gem(state) and self.kick_or_plunge(state, 1)
                 or self.kick_or_plunge(state, 2),
@@ -50,8 +48,7 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
             "Castle Spiral Climb -> Castle High Climb": lambda state:
                 self.has_gem(state)
                 or self.get_kicks(state, 3) and self.has_plunge(state)
-                or self.has_breaker(state) and self.get_kicks(state, 1)
-                or self.knows_obscure(state) and self.has_plunge(state) and self.get_kicks(state, 1),
+                or self.can_attack(state) and self.get_kicks(state, 1),
             "Castle Spiral Climb -> Castle By Scythe Corridor": lambda state:
                 self.has_gem(state),
             "Castle By Scythe Corridor -> Castle Spiral Climb": lambda state:
@@ -107,19 +104,18 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 or self.get_kicks(state, 1)
                 or self.can_bounce(state)
                 or self.can_slidejump(state),
-            "Keep Main -> Keep Path To Throne": lambda state:
-                self.has_breaker(state),
             # "Keep Locked Room -> Keep Sunsetter": lambda state: True,
             # "Keep => Underbelly -> Keep Main": lambda state: True,
             # "Keep => Underbelly -> Underbelly => Keep": lambda state: True,
-            # "Underbelly => Dungeon -> Dungeon Escape Lower": lambda state: True,
+            "Underbelly => Dungeon -> Dungeon Escape Lower": lambda state:
+                self.navigate_darkrooms(state),
             # "Underbelly => Dungeon -> Underbelly Light Pillar": lambda state: True,
             "Underbelly => Dungeon -> Underbelly Ascendant Light": lambda state:
                 self.can_bounce(state)
                 or self.has_gem(state)
                 or self.get_kicks(state, 2)
                 or self.get_kicks(state, 1) and self.can_slidejump(state)
-                or self.knows_obscure(state) and self.has_breaker(state),
+                or self.knows_obscure(state) and self.can_attack(state),
             # "Underbelly Light Pillar -> Underbelly Main Upper": lambda state: True,
             "Underbelly Light Pillar -> Underbelly => Dungeon": lambda state:
                 self.can_bounce(state)
@@ -129,8 +125,9 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 and (
                     self.has_plunge(state)
                     or self.get_kicks(state, 4))
-                or self.knows_obscure(state) and self.has_gem(state) and self.get_kicks(state, 1),
-            # "Underbelly Ascendant Light -> Underbelly Light Pillar": lambda state: True,
+                or self.knows_obscure(state) and self.has_plunge(state) and self.get_kicks(state, 1),
+            "Underbelly Ascendant Light -> Underbelly Light Pillar": lambda state:
+                self.has_breaker(state),
             "Underbelly Ascendant Light -> Underbelly => Dungeon": lambda state:
                 self.can_bounce(state)
                 or self.has_gem(state)
@@ -165,11 +162,11 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                     or self.can_slidejump(state) and self.get_kicks(state, 3)
                     or self.has_gem(state) and self.get_kicks(state, 2)),
             "Underbelly By Heliacal -> Underbelly Main Upper": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state)
+                self.has_breaker(state) and self.has_plunge(state)
+                or self.knows_obscure(state) and self.has_plunge(state)
                 and (
-                    self.get_kicks(state, 1)
-                    or self.has_gem(state) and self.can_slidejump(state)),
+                    self.has_gem(state)
+                    or self.get_kicks(state, 1)),
             # "Underbelly Little Guy -> Empty Bailey": lambda state: True,
             "Underbelly Little Guy -> Underbelly Main Lower": lambda state:
                 self.has_gem(state)
@@ -252,19 +249,15 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 self.get_kicks(state, 4)
                 or self.get_kicks(state, 2) and self.has_plunge(state),
             "Listless Library - Sun Greaves": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state) and self.has_plunge(state),
+                self.can_attack(state),
             "Listless Library - Sun Greaves 1": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state) and self.has_plunge(state),
+                self.can_attack(state),
             "Listless Library - Sun Greaves 2": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state) and self.has_plunge(state),
+                self.can_attack(state),
             "Listless Library - Sun Greaves 3": lambda state:
-                self.has_breaker(state)
-                or self.knows_obscure(state) and self.has_plunge(state),
+                self.can_attack(state),
             "Listless Library - Upper Back": lambda state:
-                (self.has_breaker(state) or self.knows_obscure(state) and self.has_plunge(state))
+                self.can_attack(state)
                 and (
                     self.has_gem(state) and self.kick_or_plunge(state, 1)
                     or self.kick_or_plunge(state, 2)),
@@ -285,19 +278,18 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
             "Sansa Keep - Sunsetter": lambda state:
                 self.can_attack(state),
             "Sansa Keep - Strikebreak": lambda state:
-                (self.can_attack(state) and (self.has_slide(state) or self.can_strikebreak(state)))
+                self.has_breaker(state) and (self.has_slide(state) or self.can_strikebreak(state))
                 and (
                     self.has_gem(state)
                     or self.has_plunge(state) and self.get_kicks(state, 1)
                     or self.get_kicks(state, 3)),
             "Sansa Keep - Lonely Throne": lambda state:
-                (self.has_gem(state)
-                 and (
-                     self.has_plunge(state) and self.get_kicks(state, 1)
-                     or self.has_plunge(state) and state.has("Ascendant Light", self.player)
-                     or self.get_kicks(state, 1) and state.has("Ascendant Light", self.player))
-                 )
-                or (state.has("Ascendant Light", self.player) and self.kick_or_plunge(state, 4)),
+                self.has_breaker(state) and self.has_gem(state)
+                and (
+                    self.has_plunge(state) and self.get_kicks(state, 1)
+                    or self.has_plunge(state) and state.has("Ascendant Light", self.player)
+                    or self.get_kicks(state, 1) and state.has("Ascendant Light", self.player)) 
+                or self.can_bounce(state) and self.kick_or_plunge(state, 4),
             # "The Underbelly - Ascendant Light": lambda state: True,
             "The Underbelly - Rafters Near Keep": lambda state:
                 self.has_plunge(state)


### PR DESCRIPTION
The main point of these changes is to fix what I call "logic mismatches" where a specific equipment loadout passes a rule on a lower difficulty but not a higher one. There were a couple rules where this happened, and I'll add a comment to those rules in the file changes. I'm confident I've found all the places where logic was broken like this.

I also changed a few other things where I thought the logic was a little questionable or where things could be added, and I cleaned up a few other things here and there. If I think something requires some explanation, I'll leave a comment. (Since logic for each rule is spread out over several files, if something applies to multiple difficulties, I'll put the comment in the file of lowest difficulty and mention which other difficulties it applies to.) Of course, feel free to leave a comment if something is unclear or it shouldn't be changed. Some of my changes are subjective, so I'm definitely opening to discussing everything.

I didn't really look at Tower/Bailey/Theatre, but I did make one small change that should hopefully make sense.

If things are looking good and we are getting ready to merge, let me know and I can cook up an accompanying PR to the poptracker pack to make sure they stay in sync.