### PR TITLE
Client settings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "AP_Randomizer/dependencies/apclientpp"]
 	path = AP_Randomizer/dependencies/apclientpp
 	url = https://github.com/black-sliver/apclientpp
+[submodule "AP_Randomizer/dependencies/tomlplusplus"]
+	path = AP_Randomizer/dependencies/tomlplusplus
+	url = https://github.com/marzer/tomlplusplus.git

--- a/AP_Randomizer/CMakeLists.txt
+++ b/AP_Randomizer/CMakeLists.txt
@@ -11,7 +11,8 @@ add_library(${TARGET} SHARED
 "src/Logger.cpp" 
 "src/StringOps.cpp" 
 "src/Timer.cpp" 
-"src/UnrealConsole.cpp")
+"src/UnrealConsole.cpp"
+"src/Settings.cpp")
 
 target_include_directories(${TARGET} PRIVATE "include")
 target_include_directories(${TARGET} PRIVATE "dependencies/apclientpp")
@@ -22,6 +23,7 @@ target_include_directories(${TARGET} PRIVATE "dependencies/wswrap/include")
 target_include_directories(${TARGET} PRIVATE "dependencies/asio/include")
 target_include_directories(${TARGET} PRIVATE "dependencies/openssl/include")
 target_include_directories(${TARGET} PRIVATE "dependencies/zlib/include")
+target_include_directories(${TARGET} PRIVATE "dependencies/tomlplusplus/include")
 target_link_libraries(${TARGET} PUBLIC UE4SS)
 target_link_libraries(${TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/openssl/lib/libcrypto.lib)
 target_link_libraries(${TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/openssl/lib/libssl.lib)

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -79,7 +79,6 @@ class PseudoregaliaWorld(World):
 
     def fill_slot_data(self) -> Dict[str, Any]:
         return {"slot_number": self.player,
-                "death_link": bool(self.options.death_link),
                 "logic_level": self.options.logic_level.value,
                 "obscure_logic": bool(self.options.obscure_logic),
                 "progressive_breaker": bool(self.options.progressive_breaker),

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from Options import Toggle, Choice, DefaultOnToggle, DeathLink, PerGameCommonOptions
+from Options import Toggle, Choice, DefaultOnToggle, PerGameCommonOptions
 from .constants.difficulties import NORMAL, HARD, EXPERT, LUNATIC
 
 
@@ -70,5 +70,4 @@ class PseudoregaliaOptions(PerGameCommonOptions):
     progressive_breaker: ProgressiveBreaker
     progressive_slide: ProgressiveSlide
     split_sun_greaves: SplitSunGreaves
-    death_link: DeathLink
 

--- a/AP_Randomizer/include/Settings.hpp
+++ b/AP_Randomizer/include/Settings.hpp
@@ -9,4 +9,5 @@ namespace Settings {
 
     void Load();
     ItemDisplay GetItemDisplay();
+    bool GetDeathLink();
 }

--- a/AP_Randomizer/include/Settings.hpp
+++ b/AP_Randomizer/include/Settings.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace Settings {
+    enum class ItemDisplay {
+        Full,
+        GenericNonPseudo,
+        GenericAll,
+    };
+
+    void Load();
+    ItemDisplay GetItemDisplay();
+}

--- a/AP_Randomizer/main.cpp
+++ b/AP_Randomizer/main.cpp
@@ -16,6 +16,7 @@
 #include "Logger.hpp"
 #include "Timer.hpp"
 #include "StringOps.hpp"
+#include "Settings.hpp"
 
 class AP_Randomizer : public RC::CppUserModBase {
 public:
@@ -36,6 +37,8 @@ public:
         ModDescription = STR("archipelago randomizer for pseudoregalia");
         ModAuthors = STR("littlemeowmeow0134");
         //ModIntendedSDKVersion = STR("2.6");
+
+        Settings::Load();
     }
 
     ~AP_Randomizer()

--- a/AP_Randomizer/settings.tmpl.toml
+++ b/AP_Randomizer/settings.tmpl.toml
@@ -4,7 +4,7 @@
 
 [settings]
 
-# item_display configures how items are displayed in your game.
+# "item_display" configures how items are displayed in your game.
 #
 # "full": Pseudoregalia items look vanilla, items from other games look different based on their classification.
 # "generic_non_pseudo": Pseudoregalia items look vanilla, items from other games all look the same.

--- a/AP_Randomizer/settings.tmpl.toml
+++ b/AP_Randomizer/settings.tmpl.toml
@@ -1,15 +1,18 @@
-# This file is a template that displays and explains the available client
-# settings. All the selections in this file are the defaults. To have the
-# client actually use your options, rename this file to "settings.toml". Every
-# release will contain "settings.tmpl.toml" so you can reference it to see if
-# there is anything new.
+# This file is a template that explains the available client settings and their options. All options selected in this
+# file are the defaults. To have the client actually use your settings, rename this file to "settings.toml". Every
+# release will contain "settings.tmpl.toml" so you can reference it to see if there is anything new.
 
 [settings]
-# "item_display" configures how items are displayed in your game.
+
+# item_display configures how items are displayed in your game.
 #
-# "full": Pseudoregalia items appear as they do in the base game, items from
-#         other games look different based on their classification.
-# "generic_non_pseudo": Pseudoregalia items appear as they do in the base game,
-#                       items from other games all look the same.
+# "full": Pseudoregalia items look vanilla, items from other games look different based on their classification.
+# "generic_non_pseudo": Pseudoregalia items look vanilla, items from other games all look the same.
 # "generic_all": All items look the same.
 item_display = "full"
+
+# "death_link" configures whether to opt in to the death link system.
+#
+# true: When you die, everyone dies. Of course the reverse is true too.
+# false: Your deaths are yours alone. There is no one else to blame.
+death_link = false

--- a/AP_Randomizer/settings.tmpl.toml
+++ b/AP_Randomizer/settings.tmpl.toml
@@ -1,0 +1,15 @@
+# This file is a template that displays and explains the available client
+# settings. All the selections in this file are the defaults. To have the
+# client actually use your options, rename this file to "settings.toml". Every
+# release will contain "settings.tmpl.toml" so you can reference it to see if
+# there is anything new.
+
+[settings]
+# "item_display" configures how items are displayed in your game.
+#
+# "full": Pseudoregalia items appear as they do in the base game, items from
+#         other games look different based on their classification.
+# "generic_non_pseudo": Pseudoregalia items appear as they do in the base game,
+#                       items from other games all look the same.
+# "generic_all": All items look the same.
+item_display = "full"

--- a/AP_Randomizer/src/Client.cpp
+++ b/AP_Randomizer/src/Client.cpp
@@ -19,6 +19,7 @@
 #include "Timer.hpp"
 #include "DeathLinkMessages.hpp"
 #include "StringOps.hpp"
+#include "Settings.hpp"
 
 namespace Client {
     using std::string;
@@ -82,11 +83,11 @@ namespace Client {
             // Executes on successful connection to slot.
             ap->set_slot_connected_handler([](const json& slot_data) {
                 Log("Connected to slot");
+                if (Settings::GetDeathLink()) {
+                    ap->ConnectUpdate(false, 0, true, list<string> {"DeathLink"});
+                }
                 for (json::const_iterator iter = slot_data.begin(); iter != slot_data.end(); iter++) {
                     GameData::SetOption(iter.key(), iter.value());
-                    if (iter.key() == "death_link" && iter.value() > 0) {
-                        ap->ConnectUpdate(false, 0, true, list<string> {"DeathLink"});
-                    }
                 }
                 ap->LocationScouts(GameData::GetLocations());
                 // Delay spawning collectibles so that we have time to receive checked locations and scouts.
@@ -244,7 +245,7 @@ namespace Client {
         using DeathLinkMessages::RandomOutgoingDeathlink;
         using DeathLinkMessages::RandomOwnDeathlink;
         if (ap == nullptr
-        || !GameData::GetOptions().at("death_link")
+        || !Settings::GetDeathLink()
         || death_link_locked) {
             return;
         }
@@ -327,7 +328,7 @@ namespace Client {
 
         void ReceiveDeathLink(const json& data) {
             if (ap == nullptr
-                || !GameData::GetOptions().at("death_link")
+                || !Settings::GetDeathLink()
                 || death_link_locked) {
                 return;
             }

--- a/AP_Randomizer/src/Client.cpp
+++ b/AP_Randomizer/src/Client.cpp
@@ -84,7 +84,7 @@ namespace Client {
                 Log("Connected to slot");
                 for (json::const_iterator iter = slot_data.begin(); iter != slot_data.end(); iter++) {
                     GameData::SetOption(iter.key(), iter.value());
-                    if (iter.key() == "death_link" || iter.value() > 0) {
+                    if (iter.key() == "death_link" && iter.value() > 0) {
                         ap->ConnectUpdate(false, 0, true, list<string> {"DeathLink"});
                     }
                 }

--- a/AP_Randomizer/src/GameData.cpp
+++ b/AP_Randomizer/src/GameData.cpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "GameData.hpp"
 #include "Logger.hpp"
+#include "Settings.hpp"
 
 namespace GameData {
     using std::unordered_map;
@@ -198,6 +199,10 @@ namespace GameData {
     }
 
     void GameData::SetPseudoItemClassification(int64_t location_id, int64_t item_id) {
+        if (Settings::GetItemDisplay() == Settings::ItemDisplay::GenericAll) {
+            return;
+        }
+
         ItemType type = lookup_item_id_to_type.at(item_id);
         switch (type) {
         case ItemType::MajorAbility:
@@ -219,6 +224,11 @@ namespace GameData {
     }
 
     void GameData::SetOffWorldItemClassification(int64_t location_id, Classification classification) {
+        if (Settings::GetItemDisplay() == Settings::ItemDisplay::GenericNonPseudo ||
+            Settings::GetItemDisplay() == Settings::ItemDisplay::GenericAll) {
+            return;
+        }
+
         lookup_location_id_to_classification[location_id] = classification;
     }
 

--- a/AP_Randomizer/src/Settings.cpp
+++ b/AP_Randomizer/src/Settings.cpp
@@ -12,37 +12,63 @@ namespace Settings {
 	using std::ifstream;
 
 	namespace {
-		const string settings_filename = "Mods/AP_Randomizer/settings.toml";
+		// if you run from the executable directory
+		const string settings_filename1 = "Mods/AP_Randomizer/settings.toml";
+		// if you run from the game directory
+		const string settings_filename2 = "pseudoregalia/Binaries/Win64/Mods/AP_Randomizer/settings.toml";
+
 		ItemDisplay item_display = ItemDisplay::Full;
+		bool death_link = false;
 	}
 
 	void Load() {
-		ifstream settings_file(settings_filename);
+		ifstream settings_file(settings_filename1);
 		if (!settings_file.good()) {
-			Log("Settings file not found");
-			return;
+			settings_file = ifstream(settings_filename2);
+			if (!settings_file.good()) {
+				Log("Settings file not found, using default settings");
+				return;
+			}
 		}
 
 		try {
 			toml::table settings_table = toml::parse(settings_file);
+			Log("Loading settings");
 
+			// item_display
 			optional<string> item_display_setting = settings_table["settings"]["item_display"].value<string>();
 			if (item_display_setting) {
-				bool set = false;
-				if (item_display_setting.value() == "generic_non_pseudo") {
+				string setting_value = item_display_setting.value();
+				if (setting_value == "full") {
+					item_display = ItemDisplay::Full;
+					Log("item_display set to " + setting_value);
+				}
+				else if (setting_value == "generic_non_pseudo") {
 					item_display = ItemDisplay::GenericNonPseudo;
-					set = true;
+					Log("item_display set to " + setting_value);
 				}
-				else if (item_display_setting.value() == "generic_all") {
+				else if (setting_value == "generic_all") {
 					item_display = ItemDisplay::GenericAll;
-					set = true;
+					Log("item_display set to " + setting_value);
 				}
-				if (set) {
-					Log("item_display set to " + item_display_setting.value());
+				else {
+					Log("Unknown option " + setting_value + " for item_display, using default option full");
 				}
 			}
+			else {
+				Log("Using default option full for item_display");
+			}
 
-			Log("Loaded settings");
+			// death_link
+			optional<bool> death_link_setting = settings_table["settings"]["death_link"].value<bool>();
+			if (death_link_setting) {
+				death_link = death_link_setting.value();
+				string setting_string = death_link_setting.value() ? "true" : "false";
+				Log("death_link set to " + setting_string);
+			}
+			else {
+				Log("Using default option false for death_link");
+			}
 		}
 		catch (const toml::parse_error& err) {
 			Log("Failed to parse settings: " + string(err.description()));
@@ -51,5 +77,9 @@ namespace Settings {
 
 	ItemDisplay GetItemDisplay() {
 		return item_display;
+	}
+
+	bool GetDeathLink() {
+		return death_link;
 	}
 }

--- a/AP_Randomizer/src/Settings.cpp
+++ b/AP_Randomizer/src/Settings.cpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <iostream>
+#include <fstream>
+#include "Logger.hpp"
+#include "Settings.hpp"
+#include "toml++/toml.hpp"
+
+namespace Settings {
+	using std::optional;
+	using std::string;
+	using std::ifstream;
+
+	namespace {
+		const string settings_filename = "Mods/AP_Randomizer/settings.toml";
+		ItemDisplay item_display = ItemDisplay::Full;
+	}
+
+	void Load() {
+		ifstream settings_file(settings_filename);
+		if (!settings_file.good()) {
+			Log("Settings file not found");
+			return;
+		}
+
+		try {
+			toml::table settings_table = toml::parse(settings_file);
+
+			optional<string> item_display_setting = settings_table["settings"]["item_display"].value<string>();
+			if (item_display_setting) {
+				bool set = false;
+				if (item_display_setting.value() == "generic_non_pseudo") {
+					item_display = ItemDisplay::GenericNonPseudo;
+					set = true;
+				}
+				else if (item_display_setting.value() == "generic_all") {
+					item_display = ItemDisplay::GenericAll;
+					set = true;
+				}
+				if (set) {
+					Log("item_display set to " + item_display_setting.value());
+				}
+			}
+
+			Log("Loaded settings");
+		}
+		catch (const toml::parse_error& err) {
+			Log("Failed to parse settings: " + string(err.description()));
+		}
+	}
+
+	ItemDisplay GetItemDisplay() {
+		return item_display;
+	}
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You'll spawn in Dungeon with Dream Breaker at its vanilla location, and you'll h
 - You can toggle Solar Wind once you've obtained it by pressing the top face button on controller or left ctrl on keyboard.
 - Entering `/popups mute` into the console will mute the sound effects of send/receive popups.
 - Entering `/popups hide` into the console will stop send/receive popups from appearing completely.
-- Client settings are defined in `pseudoregalia/Binaries/Win64/Mods/AP_Randomizer/settings.toml`. Releases include a template file in the same folder called `settings.tmpl.toml` which explains what is configurable.
+- Client settings like death link are defined in `pseudoregalia/Binaries/Win64/Mods/AP_Randomizer/settings.toml`. Releases include a template file in the same folder called `settings.tmpl.toml` which explains what is configurable.
 
 
 # Mod Installation

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You'll spawn in Dungeon with Dream Breaker at its vanilla location, and you'll h
 - You can toggle Solar Wind once you've obtained it by pressing the top face button on controller or left ctrl on keyboard.
 - Entering `/popups mute` into the console will mute the sound effects of send/receive popups.
 - Entering `/popups hide` into the console will stop send/receive popups from appearing completely.
+- Client settings are defined in `pseudoregalia/Binaries/Win64/Mods/AP_Randomizer/settings.toml`. Releases include a template file in the same folder called `settings.tmpl.toml` which explains what is configurable.
 
 
 # Mod Installation


### PR DESCRIPTION
I put a note about the existence of the client settings file in the main readme, but a lot of the info there is out of date so I'm not sure the best place for it (or if the readme just needs to be totally updated).

Client changes:
* Added client settings, which allows you to configure your client separate from the options in your player yaml file. The settings are located at `pseudoregalia/Binaries/Win64/Mods/AP_Randomizer/`. Rename the template file to `settings.toml` to have the client actually use your settings.
  * `item_display`: configures how items show up in your game
  * `death_link`: moved here from the player yaml
* Fixed a bug that added the DeathLink tag to the client even if death_link was turned off.