### PR TITLE
Shuffle outfits

### DIFF
--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -45,6 +45,9 @@ class PseudoregaliaWorld(World):
         if self.options.logic_level in (EXPERT, LUNATIC):
             # obscure is forced on for expert/lunatic difficulties
             self.options.obscure_logic.value = 1
+        if self.options.game_version != MAP_PATCH:
+            # shuffle outfits is map patch only
+            self.options.shuffle_outfits.value = 0
 
     def create_regions(self):
         for region_name in region_table.keys():
@@ -79,13 +82,16 @@ class PseudoregaliaWorld(World):
             self.multiworld.get_location(location_name, self.player).place_locked_item(locked_item)
 
     def fill_slot_data(self) -> Dict[str, Any]:
-        return {"slot_number": self.player,
-                "logic_level": self.options.logic_level.value,
-                "obscure_logic": bool(self.options.obscure_logic),
-                "progressive_breaker": bool(self.options.progressive_breaker),
-                "progressive_slide": bool(self.options.progressive_slide),
-                "split_sun_greaves": bool(self.options.split_sun_greaves),
-                "game_version": self.options.game_version.value, }
+        return {
+            "slot_number": self.player,
+            "game_version": self.options.game_version.value,
+            "logic_level": self.options.logic_level.value,
+            "obscure_logic": bool(self.options.obscure_logic),
+            "progressive_breaker": bool(self.options.progressive_breaker),
+            "progressive_slide": bool(self.options.progressive_slide),
+            "split_sun_greaves": bool(self.options.split_sun_greaves),
+            "shuffle_outfits": bool(self.options.shuffle_outfits),
+        }
 
     def set_rules(self):
         difficulty = self.options.logic_level

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -31,14 +31,17 @@ class PseudoregaliaWorld(World):
         return PseudoregaliaItem(name, data.classification, data.code, self.player)
 
     def create_items(self):
+        itempool = []
         for item_name, item_data in item_table.items():
             if not item_data.can_create(self.options) or not item_data.code:
                 continue
             precollect = item_data.precollect(self.options)
             for _ in range(precollect):
                 self.multiworld.push_precollected(self.create_item(item_name))
-            for _ in range(precollect, item_data.frequency):
-                self.multiworld.itempool.append(self.create_item(item_name))
+            itempool += [self.create_item(item_name) for _ in range(precollect, item_data.frequency)]
+        total_locations = len(self.multiworld.get_unfilled_locations(self.player))
+        itempool += [self.create_filler() for _ in range(total_locations - len(itempool))]
+        self.multiworld.itempool += itempool
 
     def generate_early(self):
         if self.options.logic_level in (EXPERT, LUNATIC):

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -23,6 +23,9 @@ class PseudoregaliaWorld(World):
     options_dataclass = PseudoregaliaOptions
     options: PseudoregaliaOptions
 
+    def get_filler_item_name(self) -> str:
+        return "Health Piece"
+
     def create_item(self, name: str) -> PseudoregaliaItem:
         data = item_table[name]
         return PseudoregaliaItem(name, data.classification, data.code, self.player)
@@ -67,8 +70,7 @@ class PseudoregaliaWorld(World):
             "progressive_breaker": bool(self.options.progressive_breaker),
             "progressive_slide": bool(self.options.progressive_slide),
             "split_sun_greaves": bool(self.options.split_sun_greaves),
-            "start_with_breaker": bool(self.options.start_with_breaker),
-            "start_with_outfits": bool(self.options.start_with_outfits),
+            "randomize_time_trials": bool(self.options.randomize_time_trials),
         }
 
     def set_rules(self):

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -10,7 +10,6 @@ from .rules_expert import PseudoregaliaExpertRules
 from .rules_lunatic import PseudoregaliaLunaticRules
 from typing import Dict, Any
 from .constants.difficulties import NORMAL, HARD, EXPERT, LUNATIC
-from .constants.versions import MAP_PATCH
 
 
 class PseudoregaliaWorld(World):
@@ -30,13 +29,11 @@ class PseudoregaliaWorld(World):
 
     def create_items(self):
         for item_name, item_data in item_table.items():
-            if not item_data.can_create(self.options):
+            if not item_data.can_create(self.options) or not item_data.code:
                 continue
             for count in range(item_data.frequency):
                 item = self.create_item(item_name)
-                if item_data.locked_location and count == 0:
-                    self.get_location(item_data.locked_location).place_locked_item(item)
-                elif item_data.precollect(self.options):
+                if item_data.precollect(self.options) and count == 0:
                     self.multiworld.push_precollected(item)
                 else:
                     self.multiworld.itempool.append(item)
@@ -56,6 +53,8 @@ class PseudoregaliaWorld(World):
             region = self.multiworld.get_region(loc_data.region, self.player)
             new_loc = PseudoregaliaLocation(self.player, loc_name, loc_data.code, region)
             region.locations.append(new_loc)
+            if loc_data.locked_item:
+                new_loc.place_locked_item(self.create_item(loc_data.locked_item))
 
         for region_name, exit_list in region_table.items():
             region = self.multiworld.get_region(region_name, self.player)
@@ -69,6 +68,7 @@ class PseudoregaliaWorld(World):
             "progressive_breaker": bool(self.options.progressive_breaker),
             "progressive_slide": bool(self.options.progressive_slide),
             "split_sun_greaves": bool(self.options.split_sun_greaves),
+            "start_with_breaker": bool(self.options.start_with_breaker),
             "start_with_outfits": bool(self.options.start_with_outfits),
         }
 

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -32,11 +32,12 @@ class PseudoregaliaWorld(World):
         for item_name, item_data in item_table.items():
             if not item_data.can_create(self.options):
                 continue
-            locked_location = item_data.locked_location(self.options)
             for count in range(item_data.frequency):
                 item = self.create_item(item_name)
-                if locked_location and count == 0:
-                    self.get_location(locked_location).place_locked_item(item)
+                if item_data.locked_location and count == 0:
+                    self.get_location(item_data.locked_location).place_locked_item(item)
+                elif item_data.precollect(self.options):
+                    self.multiworld.push_precollected(item)
                 else:
                     self.multiworld.itempool.append(item)
 
@@ -44,9 +45,6 @@ class PseudoregaliaWorld(World):
         if self.options.logic_level in (EXPERT, LUNATIC):
             # obscure is forced on for expert/lunatic difficulties
             self.options.obscure_logic.value = 1
-        if self.options.game_version != MAP_PATCH:
-            # shuffle outfits is map patch only
-            self.options.shuffle_outfits.value = 0
 
     def create_regions(self):
         for region_name in region_table.keys():
@@ -71,7 +69,7 @@ class PseudoregaliaWorld(World):
             "progressive_breaker": bool(self.options.progressive_breaker),
             "progressive_slide": bool(self.options.progressive_slide),
             "split_sun_greaves": bool(self.options.split_sun_greaves),
-            "shuffle_outfits": bool(self.options.shuffle_outfits),
+            "start_with_outfits": bool(self.options.start_with_outfits),
         }
 
     def set_rules(self):

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -31,12 +31,11 @@ class PseudoregaliaWorld(World):
         for item_name, item_data in item_table.items():
             if not item_data.can_create(self.options) or not item_data.code:
                 continue
-            for count in range(item_data.frequency):
-                item = self.create_item(item_name)
-                if item_data.precollect(self.options) and count == 0:
-                    self.multiworld.push_precollected(item)
-                else:
-                    self.multiworld.itempool.append(item)
+            precollect = item_data.precollect(self.options)
+            for _ in range(precollect):
+                self.multiworld.push_precollected(self.create_item(item_name))
+            for _ in range(precollect, item_data.frequency):
+                self.multiworld.itempool.append(self.create_item(item_name))
 
     def generate_early(self):
         if self.options.logic_level in (EXPERT, LUNATIC):

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -33,7 +33,7 @@ class PseudoregaliaWorld(World):
         for item_name, item_data in item_table.items():
             if (item_name == "Dream Breaker"):
                 continue  # Really skrunkled way of just adding the one locked breaker to the pool for now.
-            if (item_data.code and item_data.can_create(self)):
+            if (item_data.code and item_data.can_create(self.options)):
                 item_count = 1
                 if (item_name in item_frequencies):
                     item_count = item_frequencies[item_name]
@@ -54,7 +54,7 @@ class PseudoregaliaWorld(World):
             self.multiworld.regions.append(Region(region_name, self.player, self.multiworld))
 
         for loc_name, loc_data in location_table.items():
-            if not loc_data.can_create(self):
+            if not loc_data.can_create(self.options):
                 continue
             region = self.multiworld.get_region(loc_data.region, self.player)
             new_loc = PseudoregaliaLocation(self.player, loc_name, loc_data.code, region)
@@ -68,7 +68,7 @@ class PseudoregaliaWorld(World):
 
         # Place locked locations.
         for location_name, location_data in self.locked_locations.items():
-            if not location_data.can_create(self):
+            if not location_data.can_create(self.options):
                 continue
 
             # Doing this really stupidly because breaker's locking will change after logic rework is done

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -65,7 +65,6 @@ class PseudoregaliaWorld(World):
 
     def fill_slot_data(self) -> Dict[str, Any]:
         return {
-            "slot_number": self.player,
             "game_version": self.options.game_version.value,
             "logic_level": self.options.logic_level.value,
             "obscure_logic": bool(self.options.obscure_logic),

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -82,7 +82,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         classification=ItemClassification.filler),
     "Professionalism": PseudoregaliaItemData(
         code=2365810018,
-        precollect=lambda options: 1 if options.start_with_outfits else 0,
+        precollect=lambda options: 1 if options.version == MAP_PATCH and not options.randomize_time_trials else 0,
         classification=ItemClassification.filler),
 
     "Health Piece": PseudoregaliaItemData(
@@ -130,37 +130,37 @@ item_table: Dict[str, PseudoregaliaItemData] = {
     "Devotion": PseudoregaliaItemData(
         code=2365810029,
         classification=ItemClassification.filler,
-        precollect=lambda options: 1 if options.start_with_outfits else 0,
+        precollect=lambda options: 1 if not options.randomize_time_trials else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "A Guardian": PseudoregaliaItemData(
         code=2365810030,
         classification=ItemClassification.filler,
-        precollect=lambda options: 1 if options.start_with_outfits else 0,
+        precollect=lambda options: 1 if not options.randomize_time_trials else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Sweater": PseudoregaliaItemData(
         code=2365810031,
         classification=ItemClassification.filler,
-        precollect=lambda options: 1 if options.start_with_outfits else 0,
+        precollect=lambda options: 1 if not options.randomize_time_trials else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Class": PseudoregaliaItemData(
         code=2365810032,
         classification=ItemClassification.filler,
-        precollect=lambda options: 1 if options.start_with_outfits else 0,
+        precollect=lambda options: 1 if not options.randomize_time_trials else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Chivalry": PseudoregaliaItemData(
         code=2365810033,
         classification=ItemClassification.filler,
-        precollect=lambda options: 1 if options.start_with_outfits else 0,
+        precollect=lambda options: 1 if not options.randomize_time_trials else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Nostalgia": PseudoregaliaItemData(
         code=2365810034,
         classification=ItemClassification.filler,
-        precollect=lambda options: 1 if options.start_with_outfits else 0,
+        precollect=lambda options: 1 if not options.randomize_time_trials else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "A Bleeding Heart": PseudoregaliaItemData(
         code=2365810035,
         classification=ItemClassification.filler,
-        precollect=lambda options: 1 if options.start_with_outfits else 0,
+        precollect=lambda options: 1 if not options.randomize_time_trials else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
 
     "Something Worth Being Awake For": PseudoregaliaItemData(

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -12,7 +12,7 @@ class PseudoregaliaItemData(NamedTuple):
     code: int | None = None
     frequency: int = 1
     classification: ItemClassification = ItemClassification.filler
-    precollect: Callable[[PseudoregaliaOptions], bool] = lambda options: False
+    precollect: Callable[[PseudoregaliaOptions], int] = lambda options: 0
     can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True
 
 
@@ -20,7 +20,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
     "Dream Breaker": PseudoregaliaItemData(
         code=2365810001,
         classification=ItemClassification.progression,
-        precollect=lambda options: bool(options.start_with_breaker),
+        precollect=lambda options: 1 if options.start_with_breaker else 0,
         can_create=lambda options: not bool(options.progressive_breaker)),
     "Indignation": PseudoregaliaItemData(
         code=2365810002,
@@ -82,7 +82,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         classification=ItemClassification.filler),
     "Professionalism": PseudoregaliaItemData(
         code=2365810018,
-        precollect=lambda options: bool(options.start_with_outfits),
+        precollect=lambda options: 1 if options.start_with_outfits else 0,
         classification=ItemClassification.filler),
 
     "Health Piece": PseudoregaliaItemData(
@@ -124,43 +124,43 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         code=2365810028,
         frequency=3,
         classification=ItemClassification.progression,
-        precollect=lambda options: bool(options.start_with_breaker),
+        precollect=lambda options: 1 if options.start_with_breaker else 0,
         can_create=lambda options: bool(options.progressive_breaker)),
 
     "Devotion": PseudoregaliaItemData(
         code=2365810029,
         classification=ItemClassification.filler,
-        precollect=lambda options: bool(options.start_with_outfits),
+        precollect=lambda options: 1 if options.start_with_outfits else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "A Guardian": PseudoregaliaItemData(
         code=2365810030,
         classification=ItemClassification.filler,
-        precollect=lambda options: bool(options.start_with_outfits),
+        precollect=lambda options: 1 if options.start_with_outfits else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Sweater": PseudoregaliaItemData(
         code=2365810031,
         classification=ItemClassification.filler,
-        precollect=lambda options: bool(options.start_with_outfits),
+        precollect=lambda options: 1 if options.start_with_outfits else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Class": PseudoregaliaItemData(
         code=2365810032,
         classification=ItemClassification.filler,
-        precollect=lambda options: bool(options.start_with_outfits),
+        precollect=lambda options: 1 if options.start_with_outfits else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Chivalry": PseudoregaliaItemData(
         code=2365810033,
         classification=ItemClassification.filler,
-        precollect=lambda options: bool(options.start_with_outfits),
+        precollect=lambda options: 1 if options.start_with_outfits else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Nostalgia": PseudoregaliaItemData(
         code=2365810034,
         classification=ItemClassification.filler,
-        precollect=lambda options: bool(options.start_with_outfits),
+        precollect=lambda options: 1 if options.start_with_outfits else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "A Bleeding Heart": PseudoregaliaItemData(
         code=2365810035,
         classification=ItemClassification.filler,
-        precollect=lambda options: bool(options.start_with_outfits),
+        precollect=lambda options: 1 if options.start_with_outfits else 0,
         can_create=lambda options: options.game_version == MAP_PATCH),
 
     "Something Worth Being Awake For": PseudoregaliaItemData(

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -1,9 +1,7 @@
 from BaseClasses import Item, ItemClassification
-from typing import NamedTuple, Dict, Set, Callable, TYPE_CHECKING
+from typing import NamedTuple, Dict, Set, Callable, Optional
 from .constants.versions import MAP_PATCH
-
-if TYPE_CHECKING:
-    from . import PseudoregaliaWorld
+from .options import PseudoregaliaOptions
 
 
 class PseudoregaliaItem(Item):
@@ -11,38 +9,38 @@ class PseudoregaliaItem(Item):
 
 
 class PseudoregaliaItemData(NamedTuple):
-    code: int = None
+    code: Optional[int] = None
     classification: ItemClassification = ItemClassification.filler
-    can_create: "Callable[[PseudoregaliaWorld, int], bool]" = lambda world: True
+    can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True
 
 
 item_table: Dict[str, PseudoregaliaItemData] = {
     "Dream Breaker": PseudoregaliaItemData(
         code=2365810001,
         classification=ItemClassification.progression,
-        can_create=lambda world: not bool(world.options.progressive_breaker)),
+        can_create=lambda options: not bool(options.progressive_breaker)),
     "Indignation": PseudoregaliaItemData(
         code=2365810002,
         classification=ItemClassification.useful),
     "Sun Greaves": PseudoregaliaItemData(
         code=2365810003,
         classification=ItemClassification.progression,
-        can_create=lambda world: not bool(world.options.split_sun_greaves)),
+        can_create=lambda options: not bool(options.split_sun_greaves)),
     "Slide": PseudoregaliaItemData(
         code=2365810004,
         classification=ItemClassification.progression,
-        can_create=lambda world: not bool(world.options.progressive_slide)),
+        can_create=lambda options: not bool(options.progressive_slide)),
     "Solar Wind": PseudoregaliaItemData(
         code=2365810005,
         classification=ItemClassification.progression,
-        can_create=lambda world: not bool(world.options.progressive_slide)),
+        can_create=lambda options: not bool(options.progressive_slide)),
     "Sunsetter": PseudoregaliaItemData(
         code=2365810006,
         classification=ItemClassification.progression),
     "Strikebreak": PseudoregaliaItemData(
         code=2365810007,
         classification=ItemClassification.progression,
-        can_create=lambda world: not bool(world.options.progressive_breaker)),
+        can_create=lambda options: not bool(options.progressive_breaker)),
     "Cling Gem": PseudoregaliaItemData(
         code=2365810008,
         classification=ItemClassification.progression),
@@ -52,12 +50,12 @@ item_table: Dict[str, PseudoregaliaItemData] = {
     "Soul Cutter": PseudoregaliaItemData(
         code=2365810010,
         classification=ItemClassification.progression,
-        can_create=lambda world: not bool(world.options.progressive_breaker)),
+        can_create=lambda options: not bool(options.progressive_breaker)),
 
     "Heliacal Power": PseudoregaliaItemData(
         code=2365810011,
         classification=ItemClassification.progression,
-        can_create=lambda world: not bool(world.options.split_sun_greaves)),
+        can_create=lambda options: not bool(options.split_sun_greaves)),
     "Aerial Finesse": PseudoregaliaItemData(
         code=2365810012,
         classification=ItemClassification.filler),
@@ -106,47 +104,44 @@ item_table: Dict[str, PseudoregaliaItemData] = {
     "Progressive Slide": PseudoregaliaItemData(
         code=2365810026,
         classification=ItemClassification.progression,
-        can_create=lambda world: bool(world.options.progressive_slide)),
+        can_create=lambda options: bool(options.progressive_slide)),
     "Air Kick": PseudoregaliaItemData(
         code=2365810027,
         classification=ItemClassification.progression,
-        can_create=lambda world: bool(world.options.split_sun_greaves)),
+        can_create=lambda options: bool(options.split_sun_greaves)),
     "Progressive Dream Breaker": PseudoregaliaItemData(
         code=2365810028,
         classification=ItemClassification.progression,
-        can_create=lambda world: bool(world.options.progressive_breaker)),
+        can_create=lambda options: bool(options.progressive_breaker)),
 
     "Devotion": PseudoregaliaItemData(
         code=2365810029,
         classification=ItemClassification.filler,
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "A Guardian": PseudoregaliaItemData(
         code=2365810030,
         classification=ItemClassification.filler,
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "Sweater": PseudoregaliaItemData(
         code=2365810031,
         classification=ItemClassification.filler,
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "Class": PseudoregaliaItemData(
         code=2365810032,
         classification=ItemClassification.filler,
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "Chivalry": PseudoregaliaItemData(
         code=2365810033,
         classification=ItemClassification.filler,
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "Nostalgia": PseudoregaliaItemData(
         code=2365810034,
         classification=ItemClassification.filler,
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "A Bleeding Heart": PseudoregaliaItemData(
         code=2365810035,
         classification=ItemClassification.filler,
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
-
-    "Unlocked Door": PseudoregaliaItemData(
-        classification=ItemClassification.useful),
+        can_create=lambda options: options.game_version == MAP_PATCH),
 
     "Something Worth Being Awake For": PseudoregaliaItemData(
         classification=ItemClassification.progression),

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -12,15 +12,8 @@ class PseudoregaliaItemData(NamedTuple):
     code: int | None = None
     frequency: int = 1
     classification: ItemClassification = ItemClassification.filler
-    locked_location: Callable[[PseudoregaliaOptions], str | None] = lambda options: None
-    """
-    This function can return a string to indicate that the item should be placed in the corresponding location instead
-    of the item pool.
-
-    Only the first item will be locked if frequency > 1 and the rest will be placed in the item pool. If this ever needs
-    to be expanded to allow locking more than one item, the function can be changed to return List[str] instead of
-    str | None and PseudoregaliaWorld.create_items will need to be updated.
-    """
+    locked_location: str | None = None
+    precollect: Callable[[PseudoregaliaOptions], bool] = lambda options: False
     can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True
 
 
@@ -28,7 +21,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
     "Dream Breaker": PseudoregaliaItemData(
         code=2365810001,
         classification=ItemClassification.progression,
-        locked_location=lambda options: "Dilapidated Dungeon - Dream Breaker",
+        locked_location="Dilapidated Dungeon - Dream Breaker",
         can_create=lambda options: not bool(options.progressive_breaker)),
     "Indignation": PseudoregaliaItemData(
         code=2365810002,
@@ -90,7 +83,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         classification=ItemClassification.filler),
     "Professionalism": PseudoregaliaItemData(
         code=2365810018,
-        locked_location=lambda options: "Castle Sansa - Time Trial" if options.game_version == MAP_PATCH and not options.shuffle_outfits else None,
+        precollect=lambda options: bool(options.start_with_outfits),
         classification=ItemClassification.filler),
 
     "Health Piece": PseudoregaliaItemData(
@@ -132,48 +125,48 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         code=2365810028,
         frequency=3,
         classification=ItemClassification.progression,
-        locked_location=lambda options: "Dilapidated Dungeon - Dream Breaker",
+        locked_location="Dilapidated Dungeon - Dream Breaker",
         can_create=lambda options: bool(options.progressive_breaker)),
 
     "Devotion": PseudoregaliaItemData(
         code=2365810029,
         classification=ItemClassification.filler,
-        locked_location=lambda options: "Dilapidated Dungeon - Time Trial" if not options.shuffle_outfits else None,
+        precollect=lambda options: bool(options.start_with_outfits),
         can_create=lambda options: options.game_version == MAP_PATCH),
     "A Guardian": PseudoregaliaItemData(
         code=2365810030,
         classification=ItemClassification.filler,
-        locked_location=lambda options: "Sansa Keep - Time Trial" if not options.shuffle_outfits else None,
+        precollect=lambda options: bool(options.start_with_outfits),
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Sweater": PseudoregaliaItemData(
         code=2365810031,
         classification=ItemClassification.filler,
-        locked_location=lambda options: "Listless Library - Time Trial" if not options.shuffle_outfits else None,
+        precollect=lambda options: bool(options.start_with_outfits),
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Class": PseudoregaliaItemData(
         code=2365810032,
         classification=ItemClassification.filler,
-        locked_location=lambda options: "Twilight Theatre - Time Trial" if not options.shuffle_outfits else None,
+        precollect=lambda options: bool(options.start_with_outfits),
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Chivalry": PseudoregaliaItemData(
         code=2365810033,
         classification=ItemClassification.filler,
-        locked_location=lambda options: "Empty Bailey - Time Trial" if not options.shuffle_outfits else None,
+        precollect=lambda options: bool(options.start_with_outfits),
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Nostalgia": PseudoregaliaItemData(
         code=2365810034,
         classification=ItemClassification.filler,
-        locked_location=lambda options: "The Underbelly - Time Trial" if not options.shuffle_outfits else None,
+        precollect=lambda options: bool(options.start_with_outfits),
         can_create=lambda options: options.game_version == MAP_PATCH),
     "A Bleeding Heart": PseudoregaliaItemData(
         code=2365810035,
         classification=ItemClassification.filler,
-        locked_location=lambda options: "Tower Remains - Time Trial" if not options.shuffle_outfits else None,
+        precollect=lambda options: bool(options.start_with_outfits),
         can_create=lambda options: options.game_version == MAP_PATCH),
 
     "Something Worth Being Awake For": PseudoregaliaItemData(
         classification=ItemClassification.progression,
-        locked_location=lambda options: "D S T RT ED M M O   Y"),
+        locked_location="D S T RT ED M M O   Y"),
 }
 
 item_groups: Dict[str, Set[str]] = {

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -82,7 +82,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         classification=ItemClassification.filler),
     "Professionalism": PseudoregaliaItemData(
         code=2365810018,
-        precollect=lambda options: 1 if options.version == MAP_PATCH and not options.randomize_time_trials else 0,
+        precollect=lambda options: 1 if options.game_version == MAP_PATCH and not options.randomize_time_trials else 0,
         classification=ItemClassification.filler),
 
     "Health Piece": PseudoregaliaItemData(

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -14,10 +14,11 @@ class PseudoregaliaItemData(NamedTuple):
     classification: ItemClassification = ItemClassification.filler
     locked_location: Callable[[PseudoregaliaOptions], Optional[str]] = lambda options: None
     """
-    If locked_location returns a string, the item will be placed in the corresponding location instead of in the item
-    pool. If frequency > 1, only the first item will be locked and the rest will be placed in the item pool.
-    
-    If this ever needs to be expanded to allow locking more than one item, the function can return List[str] instead of
+    This function can return a string to indicate that the item should be placed in the corresponding location instead
+    of the item pool.
+
+    Only the first item will be locked if frequency > 1 and the rest will be placed in the item pool. If this ever needs
+    to be expanded to allow locking more than one item, the function can be changed to return List[str] instead of
     Optional[str] and PseudoregaliaWorld.create_items will need to be updated.
     """
     can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -12,7 +12,6 @@ class PseudoregaliaItemData(NamedTuple):
     code: int | None = None
     frequency: int = 1
     classification: ItemClassification = ItemClassification.filler
-    locked_location: str | None = None
     precollect: Callable[[PseudoregaliaOptions], bool] = lambda options: False
     can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True
 
@@ -21,7 +20,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
     "Dream Breaker": PseudoregaliaItemData(
         code=2365810001,
         classification=ItemClassification.progression,
-        locked_location="Dilapidated Dungeon - Dream Breaker",
+        precollect=lambda options: bool(options.start_with_breaker),
         can_create=lambda options: not bool(options.progressive_breaker)),
     "Indignation": PseudoregaliaItemData(
         code=2365810002,
@@ -125,7 +124,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         code=2365810028,
         frequency=3,
         classification=ItemClassification.progression,
-        locked_location="Dilapidated Dungeon - Dream Breaker",
+        precollect=lambda options: bool(options.start_with_breaker),
         can_create=lambda options: bool(options.progressive_breaker)),
 
     "Devotion": PseudoregaliaItemData(
@@ -165,8 +164,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         can_create=lambda options: options.game_version == MAP_PATCH),
 
     "Something Worth Being Awake For": PseudoregaliaItemData(
-        classification=ItemClassification.progression,
-        locked_location="D S T RT ED M M O   Y"),
+        classification=ItemClassification.progression),
 }
 
 item_groups: Dict[str, Set[str]] = {

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -1,5 +1,5 @@
 from BaseClasses import Item, ItemClassification
-from typing import NamedTuple, Dict, Set, Callable, Optional
+from typing import NamedTuple, Dict, Set, Callable
 from .constants.versions import MAP_PATCH
 from .options import PseudoregaliaOptions
 
@@ -9,17 +9,17 @@ class PseudoregaliaItem(Item):
 
 
 class PseudoregaliaItemData(NamedTuple):
-    code: Optional[int] = None
+    code: int | None = None
     frequency: int = 1
     classification: ItemClassification = ItemClassification.filler
-    locked_location: Callable[[PseudoregaliaOptions], Optional[str]] = lambda options: None
+    locked_location: Callable[[PseudoregaliaOptions], str | None] = lambda options: None
     """
     This function can return a string to indicate that the item should be placed in the corresponding location instead
     of the item pool.
 
     Only the first item will be locked if frequency > 1 and the rest will be placed in the item pool. If this ever needs
     to be expanded to allow locking more than one item, the function can be changed to return List[str] instead of
-    Optional[str] and PseudoregaliaWorld.create_items will need to be updated.
+    str | None and PseudoregaliaWorld.create_items will need to be updated.
     """
     can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True
 

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -10,7 +10,16 @@ class PseudoregaliaItem(Item):
 
 class PseudoregaliaItemData(NamedTuple):
     code: Optional[int] = None
+    frequency: int = 1
     classification: ItemClassification = ItemClassification.filler
+    locked_location: Callable[[PseudoregaliaOptions], Optional[str]] = lambda options: None
+    """
+    If locked_location returns a string, the item will be placed in the corresponding location instead of in the item
+    pool. If frequency > 1, only the first item will be locked and the rest will be placed in the item pool.
+    
+    If this ever needs to be expanded to allow locking more than one item, the function can return List[str] instead of
+    Optional[str] and PseudoregaliaWorld.create_items will need to be updated.
+    """
     can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True
 
 
@@ -18,6 +27,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
     "Dream Breaker": PseudoregaliaItemData(
         code=2365810001,
         classification=ItemClassification.progression,
+        locked_location=lambda options: "Dilapidated Dungeon - Dream Breaker",
         can_create=lambda options: not bool(options.progressive_breaker)),
     "Indignation": PseudoregaliaItemData(
         code=2365810002,
@@ -64,25 +74,31 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         classification=ItemClassification.filler),
     "Empathy": PseudoregaliaItemData(
         code=2365810014,
+        frequency=2,
         classification=ItemClassification.filler),
     "Good Graces": PseudoregaliaItemData(
         code=2365810015,
+        frequency=2,
         classification=ItemClassification.useful),
     "Martial Prowess": PseudoregaliaItemData(
         code=2365810016,
         classification=ItemClassification.useful),
     "Clear Mind": PseudoregaliaItemData(
         code=2365810017,
+        frequency=3,
         classification=ItemClassification.filler),
     "Professionalism": PseudoregaliaItemData(
         code=2365810018,
+        locked_location=lambda options: "Castle Sansa - Time Trial" if options.game_version == MAP_PATCH and not options.shuffle_outfits else None,
         classification=ItemClassification.filler),
 
     "Health Piece": PseudoregaliaItemData(
         code=2365810019,
+        frequency=16,
         classification=ItemClassification.useful),
     "Small Key": PseudoregaliaItemData(
         code=2365810020,
+        frequency=7,
         classification=ItemClassification.progression),
 
     "Major Key - Empty Bailey": PseudoregaliaItemData(
@@ -103,59 +119,60 @@ item_table: Dict[str, PseudoregaliaItemData] = {
 
     "Progressive Slide": PseudoregaliaItemData(
         code=2365810026,
+        frequency=2,
         classification=ItemClassification.progression,
         can_create=lambda options: bool(options.progressive_slide)),
     "Air Kick": PseudoregaliaItemData(
         code=2365810027,
+        frequency=4,
         classification=ItemClassification.progression,
         can_create=lambda options: bool(options.split_sun_greaves)),
     "Progressive Dream Breaker": PseudoregaliaItemData(
         code=2365810028,
+        frequency=3,
         classification=ItemClassification.progression,
+        locked_location=lambda options: "Dilapidated Dungeon - Dream Breaker",
         can_create=lambda options: bool(options.progressive_breaker)),
 
     "Devotion": PseudoregaliaItemData(
         code=2365810029,
         classification=ItemClassification.filler,
+        locked_location=lambda options: "Dilapidated Dungeon - Time Trial" if not options.shuffle_outfits else None,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "A Guardian": PseudoregaliaItemData(
         code=2365810030,
         classification=ItemClassification.filler,
+        locked_location=lambda options: "Sansa Keep - Time Trial" if not options.shuffle_outfits else None,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Sweater": PseudoregaliaItemData(
         code=2365810031,
         classification=ItemClassification.filler,
+        locked_location=lambda options: "Listless Library - Time Trial" if not options.shuffle_outfits else None,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Class": PseudoregaliaItemData(
         code=2365810032,
         classification=ItemClassification.filler,
+        locked_location=lambda options: "Twilight Theatre - Time Trial" if not options.shuffle_outfits else None,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Chivalry": PseudoregaliaItemData(
         code=2365810033,
         classification=ItemClassification.filler,
+        locked_location=lambda options: "Empty Bailey - Time Trial" if not options.shuffle_outfits else None,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "Nostalgia": PseudoregaliaItemData(
         code=2365810034,
         classification=ItemClassification.filler,
+        locked_location=lambda options: "The Underbelly - Time Trial" if not options.shuffle_outfits else None,
         can_create=lambda options: options.game_version == MAP_PATCH),
     "A Bleeding Heart": PseudoregaliaItemData(
         code=2365810035,
         classification=ItemClassification.filler,
+        locked_location=lambda options: "Tower Remains - Time Trial" if not options.shuffle_outfits else None,
         can_create=lambda options: options.game_version == MAP_PATCH),
 
     "Something Worth Being Awake For": PseudoregaliaItemData(
-        classification=ItemClassification.progression),
-}
-
-item_frequencies = {
-    "Empathy": 2,
-    "Good Graces": 2,
-    "Clear Mind": 3,
-    "Small Key": 7,
-    "Health Piece": 16,
-    "Progressive Slide": 2,
-    "Air Kick": 4,
-    "Progressive Dream Breaker": 2,  # Will need to change this later when dream breaker stops being locked to vanilla
+        classification=ItemClassification.progression,
+        locked_location=lambda options: "D S T RT ED M M O   Y"),
 }
 
 item_groups: Dict[str, Set[str]] = {

--- a/AP_Randomizer/apworld/locations.py
+++ b/AP_Randomizer/apworld/locations.py
@@ -1,9 +1,7 @@
 from BaseClasses import Location
 from typing import NamedTuple, Optional, Callable, TYPE_CHECKING
 from .constants.versions import MAP_PATCH, FULL_GOLD
-
-if TYPE_CHECKING:
-    from . import PseudoregaliaWorld
+from .options import PseudoregaliaOptions
 
 
 class PseudoregaliaLocation(Location):
@@ -13,7 +11,7 @@ class PseudoregaliaLocation(Location):
 class PseudoregaliaLocationData(NamedTuple):
     region: str
     code: int = None
-    can_create: "Callable[[PseudoregaliaWorld, int], bool]" = lambda world: True
+    can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True
     locked_item: Optional[str] = None
     show_in_spoiler: bool = True
 
@@ -66,7 +64,7 @@ location_table = {
     "Castle Sansa - Locked Door": PseudoregaliaLocationData(
         code=2365810013,
         region="Castle Main",
-        can_create=lambda world: world.options.game_version == FULL_GOLD),
+        can_create=lambda options: options.game_version == FULL_GOLD),
     "Castle Sansa - Platform In Main Halls": PseudoregaliaLocationData(
         code=2365810014,
         region="Castle Main",),
@@ -108,7 +106,7 @@ location_table = {
     "Listless Library - Sun Greaves": PseudoregaliaLocationData(
         code=2365810026,
         region="Library Greaves",
-        can_create=lambda world: not bool(world.options.split_sun_greaves)),
+        can_create=lambda options: not bool(options.split_sun_greaves)),
     "Listless Library - Upper Back": PseudoregaliaLocationData(
         code=2365810027,
         region="Library Top",),
@@ -189,77 +187,48 @@ location_table = {
     "Listless Library - Sun Greaves 1": PseudoregaliaLocationData(
         code=2365810051,
         region="Library Greaves",
-        can_create=lambda world: bool(world.options.split_sun_greaves)),
+        can_create=lambda options: bool(options.split_sun_greaves)),
     "Listless Library - Sun Greaves 2": PseudoregaliaLocationData(
         code=2365810052,
         region="Library Greaves",
-        can_create=lambda world: bool(world.options.split_sun_greaves)),
+        can_create=lambda options: bool(options.split_sun_greaves)),
     "Listless Library - Sun Greaves 3": PseudoregaliaLocationData(
         code=2365810053,
         region="Library Greaves",
-        can_create=lambda world: bool(world.options.split_sun_greaves)),
+        can_create=lambda options: bool(options.split_sun_greaves)),
     
     "Dilapidated Dungeon - Time Trial": PseudoregaliaLocationData(
         code=2365810054,
         region="Dungeon Mirror",
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "Castle Sansa - Time Trial": PseudoregaliaLocationData(
         code=2365810055,
         region="Castle Main",
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "Sansa Keep - Time Trial": PseudoregaliaLocationData(
         code=2365810056,
         region="Keep Throne Room",
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "Listless Library - Time Trial": PseudoregaliaLocationData(
         code=2365810057,
         region="Library Main",
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "Twilight Theatre - Time Trial": PseudoregaliaLocationData(
         code=2365810058,
         region="Theatre Pillar",
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "Empty Bailey - Time Trial": PseudoregaliaLocationData(
         code=2365810059,
         region="Bailey Upper",
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "The Underbelly - Time Trial": PseudoregaliaLocationData(
         code=2365810060,
         region="Underbelly Main Upper",
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH),
     "Tower Remains - Time Trial": PseudoregaliaLocationData(
         code=2365810061,
         region="The Great Door",
-        can_create=lambda world: world.options.game_version == MAP_PATCH),
-
-    "Dilapidated Dungeon - Unlock Door": PseudoregaliaLocationData(
-        region="Dungeon Strong Eyes",
-        locked_item="Unlocked Door",
-        show_in_spoiler=False),
-    "Castle Sansa - Unlock Door (Professionalism)": PseudoregaliaLocationData(
-        region="Castle Main",
-        locked_item="Unlocked Door",
-        show_in_spoiler=False),
-    "Castle Sansa - Unlock Door (Sansa Keep)": PseudoregaliaLocationData(
-        region="Castle Main",
-        locked_item="Unlocked Door",
-        show_in_spoiler=False),
-    "Sansa Keep - Unlock Door": PseudoregaliaLocationData(
-        region="Keep Main",
-        locked_item="Unlocked Door",
-        show_in_spoiler=False),
-    "Listless Library - Unlock Door": PseudoregaliaLocationData(
-        region="Library Main",
-        locked_item="Unlocked Door",
-        show_in_spoiler=False),
-    "Twilight Theatre - Unlock Door": PseudoregaliaLocationData(
-        region="Theatre Main",
-        locked_item="Unlocked Door",
-        show_in_spoiler=False),
-    "The Underbelly - Unlock Door": PseudoregaliaLocationData(
-        region="Underbelly By Heliacal",
-        locked_item="Unlocked Door",
-        show_in_spoiler=False),
+        can_create=lambda options: options.game_version == MAP_PATCH),
 
     "D S T RT ED M M O   Y": PseudoregaliaLocationData(
         region="The Great Door",

--- a/AP_Randomizer/apworld/locations.py
+++ b/AP_Randomizer/apworld/locations.py
@@ -12,8 +12,6 @@ class PseudoregaliaLocationData(NamedTuple):
     region: str
     code: int = None
     can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True
-    locked_item: Optional[str] = None
-    show_in_spoiler: bool = True
 
 
 location_table = {
@@ -23,10 +21,8 @@ location_table = {
     # Anything optional goes below the 50 base locations
 
     "Dilapidated Dungeon - Dream Breaker": PseudoregaliaLocationData(
-        # Dream Breaker can't really be shuffled right now but I would like to later
         code=2365810001,
-        region="Dungeon Mirror",
-        locked_item="Dream Breaker"),
+        region="Dungeon Mirror"),
     "Dilapidated Dungeon - Slide": PseudoregaliaLocationData(
         code=2365810002,
         region="Dungeon Slide"),
@@ -231,6 +227,5 @@ location_table = {
         can_create=lambda options: options.game_version == MAP_PATCH),
 
     "D S T RT ED M M O   Y": PseudoregaliaLocationData(
-        region="The Great Door",
-        locked_item="Something Worth Being Awake For"),
+        region="The Great Door"),
 }

--- a/AP_Randomizer/apworld/locations.py
+++ b/AP_Randomizer/apworld/locations.py
@@ -1,5 +1,5 @@
 from BaseClasses import Location
-from typing import NamedTuple, Optional, Callable, TYPE_CHECKING
+from typing import NamedTuple, Callable
 from .constants.versions import MAP_PATCH, FULL_GOLD
 from .options import PseudoregaliaOptions
 
@@ -10,7 +10,7 @@ class PseudoregaliaLocation(Location):
 
 class PseudoregaliaLocationData(NamedTuple):
     region: str
-    code: int = None
+    code: int | None = None
     can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True
 
 
@@ -60,7 +60,7 @@ location_table = {
     "Castle Sansa - Locked Door": PseudoregaliaLocationData(
         code=2365810013,
         region="Castle Main",
-        can_create=lambda options: options.game_version == FULL_GOLD),
+        can_create=lambda options: options.game_version == FULL_GOLD and not options.start_with_outfits),
     "Castle Sansa - Platform In Main Halls": PseudoregaliaLocationData(
         code=2365810014,
         region="Castle Main",),
@@ -196,35 +196,35 @@ location_table = {
     "Dilapidated Dungeon - Time Trial": PseudoregaliaLocationData(
         code=2365810054,
         region="Dungeon Mirror",
-        can_create=lambda options: options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
     "Castle Sansa - Time Trial": PseudoregaliaLocationData(
         code=2365810055,
         region="Castle Main",
-        can_create=lambda options: options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
     "Sansa Keep - Time Trial": PseudoregaliaLocationData(
         code=2365810056,
         region="Keep Throne Room",
-        can_create=lambda options: options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
     "Listless Library - Time Trial": PseudoregaliaLocationData(
         code=2365810057,
         region="Library Main",
-        can_create=lambda options: options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
     "Twilight Theatre - Time Trial": PseudoregaliaLocationData(
         code=2365810058,
         region="Theatre Pillar",
-        can_create=lambda options: options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
     "Empty Bailey - Time Trial": PseudoregaliaLocationData(
         code=2365810059,
         region="Bailey Upper",
-        can_create=lambda options: options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
     "The Underbelly - Time Trial": PseudoregaliaLocationData(
         code=2365810060,
         region="Underbelly Main Upper",
-        can_create=lambda options: options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
     "Tower Remains - Time Trial": PseudoregaliaLocationData(
         code=2365810061,
         region="The Great Door",
-        can_create=lambda options: options.game_version == MAP_PATCH),
+        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
 
     "D S T RT ED M M O   Y": PseudoregaliaLocationData(
         region="The Great Door"),

--- a/AP_Randomizer/apworld/locations.py
+++ b/AP_Randomizer/apworld/locations.py
@@ -12,6 +12,7 @@ class PseudoregaliaLocationData(NamedTuple):
     region: str
     code: int | None = None
     can_create: Callable[[PseudoregaliaOptions], bool] = lambda options: True
+    locked_item: str | None = None
 
 
 location_table = {
@@ -22,7 +23,8 @@ location_table = {
 
     "Dilapidated Dungeon - Dream Breaker": PseudoregaliaLocationData(
         code=2365810001,
-        region="Dungeon Mirror"),
+        region="Dungeon Mirror",
+        can_create=lambda options: not options.start_with_breaker),
     "Dilapidated Dungeon - Slide": PseudoregaliaLocationData(
         code=2365810002,
         region="Dungeon Slide"),
@@ -227,5 +229,6 @@ location_table = {
         can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
 
     "D S T RT ED M M O   Y": PseudoregaliaLocationData(
-        region="The Great Door"),
+        region="The Great Door",
+        locked_item="Something Worth Being Awake For"),
 }

--- a/AP_Randomizer/apworld/locations.py
+++ b/AP_Randomizer/apworld/locations.py
@@ -23,8 +23,7 @@ location_table = {
 
     "Dilapidated Dungeon - Dream Breaker": PseudoregaliaLocationData(
         code=2365810001,
-        region="Dungeon Mirror",
-        can_create=lambda options: not options.start_with_breaker),
+        region="Dungeon Mirror"),
     "Dilapidated Dungeon - Slide": PseudoregaliaLocationData(
         code=2365810002,
         region="Dungeon Slide"),
@@ -62,7 +61,7 @@ location_table = {
     "Castle Sansa - Locked Door": PseudoregaliaLocationData(
         code=2365810013,
         region="Castle Main",
-        can_create=lambda options: options.game_version == FULL_GOLD and not options.start_with_outfits),
+        can_create=lambda options: options.game_version == FULL_GOLD),
     "Castle Sansa - Platform In Main Halls": PseudoregaliaLocationData(
         code=2365810014,
         region="Castle Main",),
@@ -198,35 +197,35 @@ location_table = {
     "Dilapidated Dungeon - Time Trial": PseudoregaliaLocationData(
         code=2365810054,
         region="Dungeon Mirror",
-        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
+        can_create=lambda options: options.game_version == MAP_PATCH and options.randomize_time_trials),
     "Castle Sansa - Time Trial": PseudoregaliaLocationData(
         code=2365810055,
         region="Castle Main",
-        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
+        can_create=lambda options: options.game_version == MAP_PATCH and options.randomize_time_trials),
     "Sansa Keep - Time Trial": PseudoregaliaLocationData(
         code=2365810056,
         region="Keep Throne Room",
-        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
+        can_create=lambda options: options.game_version == MAP_PATCH and options.randomize_time_trials),
     "Listless Library - Time Trial": PseudoregaliaLocationData(
         code=2365810057,
         region="Library Main",
-        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
+        can_create=lambda options: options.game_version == MAP_PATCH and options.randomize_time_trials),
     "Twilight Theatre - Time Trial": PseudoregaliaLocationData(
         code=2365810058,
         region="Theatre Pillar",
-        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
+        can_create=lambda options: options.game_version == MAP_PATCH and options.randomize_time_trials),
     "Empty Bailey - Time Trial": PseudoregaliaLocationData(
         code=2365810059,
         region="Bailey Upper",
-        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
+        can_create=lambda options: options.game_version == MAP_PATCH and options.randomize_time_trials),
     "The Underbelly - Time Trial": PseudoregaliaLocationData(
         code=2365810060,
         region="Underbelly Main Upper",
-        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
+        can_create=lambda options: options.game_version == MAP_PATCH and options.randomize_time_trials),
     "Tower Remains - Time Trial": PseudoregaliaLocationData(
         code=2365810061,
         region="The Great Door",
-        can_create=lambda options: options.game_version == MAP_PATCH and not options.start_with_outfits),
+        can_create=lambda options: options.game_version == MAP_PATCH and options.randomize_time_trials),
 
     "D S T RT ED M M O   Y": PseudoregaliaLocationData(
         region="The Great Door",

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -78,7 +78,6 @@ class GameVersion(Choice):
 class StartWithBreaker(Toggle):
     """
     Places Dream Breaker (or one Progressive Dream Breaker) in the starting inventory.
-    Dream Breaker's vanilla location will not have an item.
     """
     display_name = "Start With Breaker"
 

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -75,12 +75,23 @@ class GameVersion(Choice):
     default = MAP_PATCH
 
 
+class ShuffleOutfits(Toggle):
+    """
+    Randomizes the outfits into the item pool and opens the time trials for randomization.
+    If turned off, the outfits can be found in their vanilla locations (e.g. Professionalism in Castle Sansa - Time Trial).
+
+    Map patch only.
+    """
+    display_name = "Shuffle Outfits"
+
+
 @dataclass
 class PseudoregaliaOptions(PerGameCommonOptions):
+    game_version: GameVersion
     logic_level: LogicLevel
     obscure_logic: ObscureLogic
     progressive_breaker: ProgressiveBreaker
     progressive_slide: ProgressiveSlide
     split_sun_greaves: SplitSunGreaves
-    game_version: GameVersion
+    shuffle_outfits: ShuffleOutfits
 

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -86,7 +86,7 @@ class StartWithBreaker(Toggle):
 class StartWithOutfits(Toggle):
     """
     Places the outfits in the starting inventory.
-    The outfit's vanilla locations (time trials) will not have items.
+    The outfits' vanilla locations (i.e. time trials) will not have items.
 
     If Full Gold version is selected, this only applies to the Professional outfit.
     """

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -75,14 +75,14 @@ class GameVersion(Choice):
     default = MAP_PATCH
 
 
-class ShuffleOutfits(Toggle):
+class StartWithOutfits(Toggle):
     """
-    Randomizes the outfits into the item pool and opens the time trials for randomization.
-    If turned off, the outfits can be found in their vanilla locations (e.g. Professionalism in Castle Sansa - Time Trial).
+    Places the outfits in the starting inventory.
+    If turned off, the outfits are randomized into the item pool and the time trials are opened for randomization.
 
-    This option is automatically turned off on Full Gold patch.
+    If Full Gold version is selected, this only affects the Professional outfit.
     """
-    display_name = "Shuffle Outfits"
+    display_name = "Start With Outfits"
 
 
 @dataclass
@@ -93,5 +93,5 @@ class PseudoregaliaOptions(PerGameCommonOptions):
     progressive_breaker: ProgressiveBreaker
     progressive_slide: ProgressiveSlide
     split_sun_greaves: SplitSunGreaves
-    shuffle_outfits: ShuffleOutfits
+    start_with_outfits: StartWithOutfits
 

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -75,6 +75,14 @@ class GameVersion(Choice):
     default = MAP_PATCH
 
 
+class StartWithBreaker(Toggle):
+    """
+    Places Dream Breaker (or one Progressive Dream Breaker) in the starting inventory.
+    If turned on, Dream Breaker's vanilla location will not have an item.
+    """
+    display_name = "Start With Breaker"
+
+
 class StartWithOutfits(Toggle):
     """
     Places the outfits in the starting inventory.
@@ -93,5 +101,6 @@ class PseudoregaliaOptions(PerGameCommonOptions):
     progressive_breaker: ProgressiveBreaker
     progressive_slide: ProgressiveSlide
     split_sun_greaves: SplitSunGreaves
+    start_with_breaker: StartWithBreaker
     start_with_outfits: StartWithOutfits
 

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -78,7 +78,7 @@ class GameVersion(Choice):
 class StartWithBreaker(Toggle):
     """
     Places Dream Breaker (or one Progressive Dream Breaker) in the starting inventory.
-    If turned on, Dream Breaker's vanilla location will not have an item.
+    Dream Breaker's vanilla location will not have an item.
     """
     display_name = "Start With Breaker"
 
@@ -86,9 +86,9 @@ class StartWithBreaker(Toggle):
 class StartWithOutfits(Toggle):
     """
     Places the outfits in the starting inventory.
-    If turned off, the outfits are randomized into the item pool and the time trials are opened for randomization.
+    The outfit's vanilla locations (time trials) will not have items.
 
-    If Full Gold version is selected, this only affects the Professional outfit.
+    If Full Gold version is selected, this only applies to the Professional outfit.
     """
     display_name = "Start With Outfits"
 

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -80,7 +80,7 @@ class ShuffleOutfits(Toggle):
     Randomizes the outfits into the item pool and opens the time trials for randomization.
     If turned off, the outfits can be found in their vanilla locations (e.g. Professionalism in Castle Sansa - Time Trial).
 
-    Map patch only.
+    This option is automatically turned off on Full Gold patch.
     """
     display_name = "Shuffle Outfits"
 

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -83,14 +83,14 @@ class StartWithBreaker(Toggle):
     display_name = "Start With Breaker"
 
 
-class StartWithOutfits(Toggle):
+class RandomizeTimeTrials(Toggle):
     """
-    Places the outfits in the starting inventory.
-    The outfits' vanilla locations (i.e. time trials) will not have items.
+    Opens the time trials for randomization and puts the outfits in the item pool.
+    If turned off, the time trials will not have items and the outfits are placed in the starting inventory.
 
-    If Full Gold version is selected, this only applies to the Professional outfit.
+    If Full Gold version is selected, this option has no effect.
     """
-    display_name = "Start With Outfits"
+    display_name = "Randomize Time Trials"
 
 
 @dataclass
@@ -102,5 +102,5 @@ class PseudoregaliaOptions(PerGameCommonOptions):
     progressive_slide: ProgressiveSlide
     split_sun_greaves: SplitSunGreaves
     start_with_breaker: StartWithBreaker
-    start_with_outfits: StartWithOutfits
+    randomize_time_trials: RandomizeTimeTrials
 

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -125,7 +125,7 @@ class PseudoregaliaRulesHelpers:
                 else:
                     add_rule(entrance, rule, "or")
         for name, rules in self.location_rules.items():
-            if not location_table[name].can_create(world):
+            if not location_table[name].can_create(world.options):
                 continue
             location = multiworld.get_location(name, self.player)
             for index, rule in enumerate(rules):

--- a/AP_Randomizer/include/Engine.hpp
+++ b/AP_Randomizer/include/Engine.hpp
@@ -15,5 +15,6 @@ namespace Engine {
 	void ToggleSlideJump();
 	void VaporizeGoat();
 	void VerifyVersion();
+	void SpawnTimeTrialCollectibleIfBeaten(UObject*);
 	void SpawnTimeTrialCollectibleIfBeaten(UObject*, int64_t, GameData::Collectible);
 }

--- a/AP_Randomizer/main.cpp
+++ b/AP_Randomizer/main.cpp
@@ -96,14 +96,7 @@ public:
                 Client::SendDeathLink();
                 };
             auto spawntimetrialcollectible = [](UnrealScriptFunctionCallableContext& context, void* customdata) {
-                std::wstring name = context.Context->GetName();
-                auto id_collectible_pair = GameData::GetTimeTrialCollectible(Engine::GetCurrentMap(), name);
-                if (!id_collectible_pair) {
-                    Log(L"Collectible not found for time trial " + name);
-                    return;
-                }
-                auto& [location_id, collectible] = *id_collectible_pair;
-                Engine::SpawnTimeTrialCollectibleIfBeaten(context.Context, location_id, collectible);
+                Engine::SpawnTimeTrialCollectibleIfBeaten(context.Context);
                 };
 
             if (!returncheck_hooked

--- a/AP_Randomizer/src/Engine.cpp
+++ b/AP_Randomizer/src/Engine.cpp
@@ -193,6 +193,21 @@ namespace Engine {
 		}
 	}
 
+	void SpawnTimeTrialCollectibleIfBeaten(UObject* obj) {
+		wstring name = obj->GetName();
+		auto id_collectible_pair = GameData::GetTimeTrialCollectible(GetCurrentMap(), name);
+		if (!id_collectible_pair) {
+			Log(L"Collectible not found for time trial " + name);
+			return;
+		}
+		auto& [id, collectible] = *id_collectible_pair;
+		if (!collectible.CanCreate(GameData::GetOptions())) {
+			Log(L"Collectible with id " + std::to_wstring(id) + L" was not spawned because its required options were not met.");
+			return;
+		}
+		SpawnTimeTrialCollectibleIfBeaten(obj, id, collectible);
+	}
+
 	void SpawnTimeTrialCollectibleIfBeaten(UObject* obj, int64_t id, GameData::Collectible collectible) {
 		int32_t medal_tier = *static_cast<int32_t*>(obj->GetValuePtrByPropertyName(L"medalTier"));
 		if (medal_tier < 1) {

--- a/AP_Randomizer/src/GameData.cpp
+++ b/AP_Randomizer/src/GameData.cpp
@@ -288,7 +288,7 @@ namespace GameData {
             // Strong Eyes
                 {2365810007, Collectible(FVector(750, 8850, 2650))},
             // Time Trial
-                {2365810054, Collectible(FVector(-3350, -4300, 850), vector<pair<string, int>>{{"game_version", MAP_PATCH}}, L"BP_TimeTrial_C_1")},
+                {2365810054, Collectible(FVector(-3350, -4300, 850), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_1")},
                     }},
             {Map::Castle, unordered_map<int64_t, Collectible> {
             // Indignation
@@ -302,7 +302,7 @@ namespace GameData {
             // Floater In Courtyard
                 {2365810012, Collectible(FVector(-5000, -600, 2050))},
             // Locked Door
-                {2365810013, Collectible(FVector(2700, -1700, -500), vector<pair<string, int>>{{"game_version", FULL_GOLD}})},
+                {2365810013, Collectible(FVector(2700, -1700, -500), vector<pair<string, int>>{{"game_version", FULL_GOLD}, {"start_with_outfits", false}})},
             // Platform In Main Halls
                 {2365810014, Collectible(FVector(7950, 2750, -200))},
             // Tall Room Near Wheel Crawlers
@@ -316,7 +316,7 @@ namespace GameData {
             // Near Theatre Front
                 {2365810019, Collectible(FVector(3390, 21150, 6600))},
             // Time Trial
-                {2365810055, Collectible(FVector(3200, -1700, -500), vector<pair<string, int>>{{"game_version", MAP_PATCH}}, L"BP_TimeTrial_C_1")},
+                {2365810055, Collectible(FVector(3200, -1700, -500), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_1")},
                     }},
             {Map::Keep, unordered_map<int64_t, Collectible> {
             // Strikebreak
@@ -332,7 +332,7 @@ namespace GameData {
             // Sunsetter
                 {2365810025, Collectible(FVector(-3000, 4900, -400))},
             // Time Trial
-                {2365810056, Collectible(FVector(14350, 400, 1250), vector<pair<string, int>>{{"game_version", MAP_PATCH}}, L"BP_TimeTrial_C_3")},
+                {2365810056, Collectible(FVector(14350, 400, 1250), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_3")},
                     }},
             {Map::Library, unordered_map<int64_t, Collectible> {
             // Sun Greaves
@@ -350,7 +350,7 @@ namespace GameData {
             // Split Greaves 3
                 {2365810053, Collectible(FVector(-4200, 9250, -100), vector<pair<string, int>>{{"split_sun_greaves", true}})},
             // Time Trial
-                {2365810057, Collectible(FVector(-2850, 3600, 900), vector<pair<string, int>>{{"game_version", MAP_PATCH}}, L"BP_TimeTrial_C_2")},
+                {2365810057, Collectible(FVector(-2850, 3600, 900), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_2")},
                     }},
             {Map::Theatre, unordered_map<int64_t, Collectible> {
             // Soul Cutter
@@ -366,7 +366,7 @@ namespace GameData {
             // Corner Beam
                 {2365810035, Collectible(FVector(-14100, -150, 1950))},
             // Time Trial
-                {2365810058, Collectible(FVector(-14750, 3900, 100), vector<pair<string, int>>{{"game_version", MAP_PATCH}}, L"BP_TimeTrial_C_1")},
+                {2365810058, Collectible(FVector(-14750, 3900, 100), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_1")},
                     }},
             {Map::Bailey, unordered_map<int64_t, Collectible> {
             // Solar Wind
@@ -380,7 +380,7 @@ namespace GameData {
             // Inside Building
                 {2365810040, Collectible(FVector(3007, 3457, 300))},
             // Time Trial
-                {2365810059, Collectible(FVector(1150, 5250, -600), vector<pair<string, int>>{{"game_version", MAP_PATCH}}, L"BP_TimeTrial_C_1")},
+                {2365810059, Collectible(FVector(1150, 5250, -600), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_1")},
                     }},
             {Map::Underbelly, unordered_map<int64_t, Collectible> {
             // Ascendant Light
@@ -400,7 +400,7 @@ namespace GameData {
             // Surrounded By Holes
                 {2365810048, Collectible(FVector(33050, 24100, 3850), tuple<FVector, string, int>{FVector(31900, 26250, 3850), "game_version", FULL_GOLD})},
             // Time Trial
-                {2365810060, Collectible(FVector(1250, 18000, 3000), vector<pair<string, int>>{{"game_version", MAP_PATCH}}, L"BP_TimeTrial_C_1")},
+                {2365810060, Collectible(FVector(1250, 18000, 3000), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_1")},
                     }},
             {Map::Tower, unordered_map<int64_t, Collectible> {
             // Cling Gem
@@ -408,7 +408,7 @@ namespace GameData {
             // Atop The Tower
                 {2365810050, Collectible(FVector(9650, 5250, 7100))},
             // Time Trial
-                {2365810061, Collectible(FVector(10750, 3050, 4000), vector<pair<string, int>>{{"game_version", MAP_PATCH}}, L"BP_TimeTrial_C_3")},
+                {2365810061, Collectible(FVector(10750, 3050, 4000), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_3")},
                     }},
         };
 

--- a/AP_Randomizer/src/GameData.cpp
+++ b/AP_Randomizer/src/GameData.cpp
@@ -274,7 +274,7 @@ namespace GameData {
         collectible_table = {
             {Map::Dungeon, unordered_map<int64_t, Collectible>{
             // Dream Breaker
-                {2365810001, Collectible(FVector(-3500.0, 4950.0, -50.0), vector<pair<string, int>>{{"start_with_breaker", false}})},
+                {2365810001, Collectible(FVector(-3500.0, 4950.0, -50.0))},
             // Slide
                 {2365810002, Collectible(FVector(16650, 2600, 2350))},
             // Alcove Near Mirror
@@ -288,7 +288,7 @@ namespace GameData {
             // Strong Eyes
                 {2365810007, Collectible(FVector(750, 8850, 2650))},
             // Time Trial
-                {2365810054, Collectible(FVector(-3350, -4300, 850), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_1")},
+                {2365810054, Collectible(FVector(-3350, -4300, 850), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"randomize_time_trials", true}}, L"BP_TimeTrial_C_1")},
                     }},
             {Map::Castle, unordered_map<int64_t, Collectible> {
             // Indignation
@@ -302,7 +302,7 @@ namespace GameData {
             // Floater In Courtyard
                 {2365810012, Collectible(FVector(-5000, -600, 2050))},
             // Locked Door
-                {2365810013, Collectible(FVector(2700, -1700, -500), vector<pair<string, int>>{{"game_version", FULL_GOLD}, {"start_with_outfits", false}})},
+                {2365810013, Collectible(FVector(2700, -1700, -500), vector<pair<string, int>>{{"game_version", FULL_GOLD}})},
             // Platform In Main Halls
                 {2365810014, Collectible(FVector(7950, 2750, -200))},
             // Tall Room Near Wheel Crawlers
@@ -316,7 +316,7 @@ namespace GameData {
             // Near Theatre Front
                 {2365810019, Collectible(FVector(3390, 21150, 6600))},
             // Time Trial
-                {2365810055, Collectible(FVector(3200, -1700, -500), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_1")},
+                {2365810055, Collectible(FVector(3200, -1700, -500), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"randomize_time_trials", true}}, L"BP_TimeTrial_C_1")},
                     }},
             {Map::Keep, unordered_map<int64_t, Collectible> {
             // Strikebreak
@@ -332,7 +332,7 @@ namespace GameData {
             // Sunsetter
                 {2365810025, Collectible(FVector(-3000, 4900, -400))},
             // Time Trial
-                {2365810056, Collectible(FVector(14350, 400, 1250), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_3")},
+                {2365810056, Collectible(FVector(14350, 400, 1250), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"randomize_time_trials", true}}, L"BP_TimeTrial_C_3")},
                     }},
             {Map::Library, unordered_map<int64_t, Collectible> {
             // Sun Greaves
@@ -350,7 +350,7 @@ namespace GameData {
             // Split Greaves 3
                 {2365810053, Collectible(FVector(-4200, 9250, -100), vector<pair<string, int>>{{"split_sun_greaves", true}})},
             // Time Trial
-                {2365810057, Collectible(FVector(-2850, 3600, 900), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_2")},
+                {2365810057, Collectible(FVector(-2850, 3600, 900), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"randomize_time_trials", true}}, L"BP_TimeTrial_C_2")},
                     }},
             {Map::Theatre, unordered_map<int64_t, Collectible> {
             // Soul Cutter
@@ -366,7 +366,7 @@ namespace GameData {
             // Corner Beam
                 {2365810035, Collectible(FVector(-14100, -150, 1950))},
             // Time Trial
-                {2365810058, Collectible(FVector(-14750, 3900, 100), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_1")},
+                {2365810058, Collectible(FVector(-14750, 3900, 100), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"randomize_time_trials", true}}, L"BP_TimeTrial_C_1")},
                     }},
             {Map::Bailey, unordered_map<int64_t, Collectible> {
             // Solar Wind
@@ -380,7 +380,7 @@ namespace GameData {
             // Inside Building
                 {2365810040, Collectible(FVector(3007, 3457, 300))},
             // Time Trial
-                {2365810059, Collectible(FVector(1150, 5250, -600), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_1")},
+                {2365810059, Collectible(FVector(1150, 5250, -600), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"randomize_time_trials", true}}, L"BP_TimeTrial_C_1")},
                     }},
             {Map::Underbelly, unordered_map<int64_t, Collectible> {
             // Ascendant Light
@@ -400,7 +400,7 @@ namespace GameData {
             // Surrounded By Holes
                 {2365810048, Collectible(FVector(33050, 24100, 3850), tuple<FVector, string, int>{FVector(31900, 26250, 3850), "game_version", FULL_GOLD})},
             // Time Trial
-                {2365810060, Collectible(FVector(1250, 18000, 3000), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_1")},
+                {2365810060, Collectible(FVector(1250, 18000, 3000), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"randomize_time_trials", true}}, L"BP_TimeTrial_C_1")},
                     }},
             {Map::Tower, unordered_map<int64_t, Collectible> {
             // Cling Gem
@@ -408,7 +408,7 @@ namespace GameData {
             // Atop The Tower
                 {2365810050, Collectible(FVector(9650, 5250, 7100))},
             // Time Trial
-                {2365810061, Collectible(FVector(10750, 3050, 4000), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"start_with_outfits", false}}, L"BP_TimeTrial_C_3")},
+                {2365810061, Collectible(FVector(10750, 3050, 4000), vector<pair<string, int>>{{"game_version", MAP_PATCH}, {"randomize_time_trials", true}}, L"BP_TimeTrial_C_3")},
                     }},
         };
 

--- a/AP_Randomizer/src/GameData.cpp
+++ b/AP_Randomizer/src/GameData.cpp
@@ -274,7 +274,7 @@ namespace GameData {
         collectible_table = {
             {Map::Dungeon, unordered_map<int64_t, Collectible>{
             // Dream Breaker
-                {2365810001, Collectible(FVector(-3500.0, 4950.0, -50.0))},
+                {2365810001, Collectible(FVector(-3500.0, 4950.0, -50.0), vector<pair<string, int>>{{"start_with_breaker", false}})},
             // Slide
                 {2365810002, Collectible(FVector(16650, 2600, 2350))},
             // Alcove Near Mirror


### PR DESCRIPTION
Changes
* added start_with_outfits option. if on, time trial locations do not get created
* added start_with_breaker option, if on, dream breaker location does not get created
* reworked locked items to not make an exception of dream breaker
* reworked can_create functions to take options as argument since that's all they ever look at inside world
* reformatted slot data
* removed Unlocked Door events since they were not being used
* removed show_in_spoiler since only the doors were using it
* moved item_frequency to a field on item data to remove coupling