### PR TITLE
Castle spawn

### DIFF
--- a/AP_Randomizer/apworld/regions.py
+++ b/AP_Randomizer/apworld/regions.py
@@ -10,7 +10,8 @@ class RegionExit(NamedTuple):
 
 region_table: Dict[str, List[str]] = {
     "Menu":
-        ["Dungeon Mirror"],
+        ["Castle Main"],
+
     "Dungeon Mirror":
         ["Dungeon Slide"],
     "Dungeon Slide":

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -1,7 +1,7 @@
 from BaseClasses import CollectionState
 from typing import Dict, Callable, TYPE_CHECKING
 from worlds.generic.Rules import add_rule, set_rule, CollectionRule
-from .constants.difficulties import NORMAL
+from .constants.difficulties import NORMAL, EXPERT, LUNATIC
 from .locations import location_table
 
 if TYPE_CHECKING:
@@ -94,8 +94,9 @@ class PseudoregaliaRulesHelpers:
         return state.count("Small Key", self.player) >= self.required_small_keys
 
     def navigate_darkrooms(self, state) -> bool:
-        # TODO: Update this to check obscure tricks for breaker only when logic rework nears completion
-        return self.has_breaker(state) or state.has("Ascendant Light", self.player)
+        return (state.has("Ascendant Light", self.player)
+                or self.knows_obscure(state) and self.has_breaker(state)  # throw breaker for light
+                or self.world.options.logic_level in (EXPERT, LUNATIC))  # navigate without light
 
     def can_slidejump(self, state) -> bool:
         return (state.has_all({"Slide", "Solar Wind"}, self.player)

--- a/AP_Randomizer/apworld/rules_normal.py
+++ b/AP_Randomizer/apworld/rules_normal.py
@@ -71,7 +71,7 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
             "Dungeon Slide -> Dungeon Strong Eyes": lambda state:
                 self.has_slide(state),
             "Dungeon Slide -> Dungeon Escape Lower": lambda state:
-                self.can_attack(state) and self.navigate_darkrooms(state),
+                self.knows_obscure(state) and self.can_attack(state) and self.navigate_darkrooms(state),
             "Dungeon Strong Eyes -> Dungeon Slide": lambda state:
                 self.has_slide(state),
             "Dungeon Strong Eyes -> Dungeon => Castle": lambda state:


### PR DESCRIPTION
Changes
* `Menu` region exits to `Castle Main`
* `Dungeon Slide -> Dungeon Escape Lower` requires obscure since it will no longer be necessary with castle spawn
* `navigate_darkrooms` requires obscure for throwing breaker for light, and may expect nothing on expert/lunatic

for the `navigate_darkrooms` change, I wanted to incorporate being required to navigate in the dark. if you like this design with that being expected on expert/lunatic but not necessarily normal/hard on obscure, I can memoize it like `knows_obscure` and `can_attack`. I didn't do that yet in case you wanted to change this implementation
