### PR TITLE
Underbelly logic

### DIFF
--- a/AP_Randomizer/apworld/locations.py
+++ b/AP_Randomizer/apworld/locations.py
@@ -157,7 +157,7 @@ location_table = {
         region="Underbelly Light Pillar",),
     "The Underbelly - Building Near Little Guy": PseudoregaliaLocationData(
         code=2365810043,
-        region="Underbelly Little Guy",),
+        region="Underbelly => Bailey",),
     "The Underbelly - Locked Door": PseudoregaliaLocationData(
         code=2365810044,
         region="Underbelly By Heliacal",),

--- a/AP_Randomizer/apworld/regions.py
+++ b/AP_Randomizer/apworld/regions.py
@@ -90,7 +90,7 @@ region_table: Dict[str, List[str]] = {
          "Theatre Pillar => Bailey",],
     "Bailey Upper":
         ["Bailey Lower",
-         "Underbelly Little Guy",
+         "Underbelly => Bailey",
          "Tower Remains",],
     "Tower Remains":
         ["The Great Door",],
@@ -106,7 +106,7 @@ region_table: Dict[str, List[str]] = {
     "Underbelly Ascendant Light":
         ["Underbelly => Dungeon"],
     "Underbelly Main Lower":
-        ["Underbelly Little Guy",
+        ["Underbelly => Bailey",
          "Underbelly Hole",
          "Underbelly By Heliacal",
          "Underbelly Main Upper"],
@@ -116,7 +116,7 @@ region_table: Dict[str, List[str]] = {
          "Underbelly By Heliacal"],
     "Underbelly By Heliacal":
         ["Underbelly Main Upper"],
-    "Underbelly Little Guy":
+    "Underbelly => Bailey":
         ["Bailey Upper",
          "Bailey Lower",
          "Underbelly Main Lower",],

--- a/AP_Randomizer/apworld/regions.py
+++ b/AP_Randomizer/apworld/regions.py
@@ -104,8 +104,7 @@ region_table: Dict[str, List[str]] = {
          "Underbelly => Dungeon",
          "Underbelly Ascendant Light"],
     "Underbelly Ascendant Light":
-        ["Underbelly Light Pillar",
-         "Underbelly => Dungeon"],
+        ["Underbelly => Dungeon"],
     "Underbelly Main Lower":
         ["Underbelly Little Guy",
          "Underbelly Hole",

--- a/AP_Randomizer/apworld/rules_expert.py
+++ b/AP_Randomizer/apworld/rules_expert.py
@@ -75,10 +75,7 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
             "Keep Main -> Theatre Outside Scythe Corridor": lambda state:
                 self.has_slide(state),
             "Underbelly => Dungeon -> Underbelly Ascendant Light": lambda state:
-                self.get_kicks(state, 1)
-                and (
-                    self.has_slide(state)
-                    or self.has_plunge(state)),
+                self.get_kicks(state, 1) and self.has_slide(state),
             "Underbelly Light Pillar -> Underbelly => Dungeon": lambda state:
                 self.has_slide(state) and self.kick_or_plunge(state, 2)
                 or self.has_plunge(state) and self.get_kicks(state, 2),
@@ -127,9 +124,6 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
                 and (
                     self.has_gem(state)
                     or self.get_kicks(state, 2)),
-            # "Underbelly => Bailey -> Bailey Upper": lambda state: True,  # technically already true because obscure
-            "Underbelly Hole -> Underbelly Main Lower": lambda state:
-                self.has_plunge(state) and self.has_slide(state),
         }
 
         location_clauses = {

--- a/AP_Randomizer/apworld/rules_expert.py
+++ b/AP_Randomizer/apworld/rules_expert.py
@@ -127,7 +127,7 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
                 and (
                     self.has_gem(state)
                     or self.get_kicks(state, 2)),
-            # "Underbelly Little Guy -> Bailey Upper": lambda state: True,  # technically already true because obscure
+            # "Underbelly => Bailey -> Bailey Upper": lambda state: True,  # technically already true because obscure
             "Underbelly Hole -> Underbelly Main Lower": lambda state:
                 self.has_plunge(state) and self.has_slide(state),
         }

--- a/AP_Randomizer/apworld/rules_expert.py
+++ b/AP_Randomizer/apworld/rules_expert.py
@@ -75,43 +75,47 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
             "Keep Main -> Theatre Outside Scythe Corridor": lambda state:
                 self.has_slide(state),
             "Underbelly => Dungeon -> Underbelly Ascendant Light": lambda state:
-                self.has_breaker(state)
-                or self.get_kicks(state, 1) and self.has_slide(state),
+                self.get_kicks(state, 1)
+                and (
+                    self.has_slide(state)
+                    or self.has_plunge(state)),
             "Underbelly Light Pillar -> Underbelly => Dungeon": lambda state:
-                self.has_slide(state) and self.kick_or_plunge(state, 2),
+                self.has_slide(state) and self.kick_or_plunge(state, 2)
+                or self.has_plunge(state) and self.get_kicks(state, 2),
             "Underbelly Light Pillar -> Underbelly Ascendant Light": lambda state:
-                self.has_breaker(state)
+                self.has_plunge(state) and self.get_kicks(state, 1)
+                or self.has_slide(state)
                 and (
-                    self.get_kicks(state, 2)
-                    or self.get_kicks(state, 1) and self.has_gem(state)
-                    or self.has_slide(state))
-                or self.has_plunge(state)
-                and (
-                    self.has_gem(state)
-                    or self.get_kicks(state, 1)
-                    or self.has_slide(state)),
+                    self.can_attack(state)
+                    or self.get_kicks(state, 3) and self.has_gem(state)),
             "Underbelly Ascendant Light -> Underbelly => Dungeon": lambda state:
-                self.has_slide(state) and self.get_kicks(state, 1),
+                self.get_kicks(state, 1)
+                and (
+                    self.has_slide(state)
+                    or self.has_plunge(state)),
             "Underbelly Main Lower -> Underbelly Hole": lambda state:
                 self.has_plunge(state) and self.has_slide(state),
             "Underbelly Main Lower -> Underbelly By Heliacal": lambda state:
                 self.has_slide(state),
             "Underbelly Main Lower -> Underbelly Main Upper": lambda state:
-                self.has_gem(state) and self.kick_or_plunge(state, 1)
-                or self.get_kicks(state, 4)
+                self.get_kicks(state, 2)
+                or self.get_kicks(state, 1) and self.has_gem(state)
+                or self.has_slide(state) and self.has_gem(state)
+                or self.has_slide(state) and self.get_kicks(state, 1) and self.has_breaker(state),
+            "Underbelly Main Upper -> Underbelly Light Pillar": lambda state:
+                self.has_breaker(state)
+                and (
+                    self.has_slide(state)
+                    or self.get_kicks(state, 1))
                 or self.has_slide(state)
                 and (
-                    self.has_gem(state)
-                    or self.get_kicks(state, 3)
-                    or self.get_kicks(state, 1) and self.has_plunge(state)
-                    or self.get_kicks(state, 1) and self.has_breaker(state)),
-            "Underbelly Main Upper -> Underbelly Light Pillar": lambda state:
-                self.has_breaker(state) and self.has_slide(state)
-                or self.has_slide(state) and self.get_kicks(state, 1)
-                or self.has_plunge(state) and self.get_kicks(state, 2)
-                or self.has_gem(state) and self.get_kicks(state, 2),
+                    self.kick_or_plunge(state, 2)
+                    or self.has_gem(state)),
             "Underbelly Main Upper -> Underbelly By Heliacal": lambda state:
-                self.has_breaker(state) and self.has_slide(state) and self.get_kicks(state, 2),
+                self.has_breaker(state)
+                and (
+                    self.has_slide(state) and self.get_kicks(state, 2)
+                    or self.get_kicks(state, 3)),
             "Underbelly By Heliacal -> Underbelly Main Upper": lambda state:
                 self.has_plunge(state)
                 or self.has_breaker(state)
@@ -125,7 +129,7 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
                     or self.get_kicks(state, 2)),
             # "Underbelly Little Guy -> Bailey Upper": lambda state: True,  # technically already true because obscure
             "Underbelly Hole -> Underbelly Main Lower": lambda state:
-                self.has_slide(state),
+                self.has_plunge(state) and self.has_slide(state),
         }
 
         location_clauses = {
@@ -216,11 +220,12 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
             "The Underbelly - Strikebreak Wall": lambda state:
                 self.can_strikebreak(state)
                 and (
-                    self.has_slide(state) and self.kick_or_plunge(state, 1)
+                    self.get_kicks(state, 1) and self.has_plunge(state)
+                    or self.has_slide(state) and self.get_kicks(state, 2)
                     or self.has_slide(state) and self.has_gem(state)),
             "The Underbelly - Surrounded By Holes": lambda state:
                 self.can_soulcutter(state) and self.has_slide(state)
-                or self.has_slide(state) and self.get_kicks(state, 1),
+                or self.has_slide(state) and self.get_kicks(state, 1) and self.has_plunge(state),
         }
 
         self.apply_clauses(region_clauses, location_clauses)

--- a/AP_Randomizer/apworld/rules_hard.py
+++ b/AP_Randomizer/apworld/rules_hard.py
@@ -73,11 +73,10 @@ class PseudoregaliaHardRules(PseudoregaliaNormalRules):
                 or self.has_breaker(state) and self.has_plunge(state) and self.get_kicks(state, 4)
                 or self.can_bounce(state) and self.get_kicks(state, 3),
             "Underbelly Light Pillar -> Underbelly Ascendant Light": lambda state:
-                self.has_breaker(state) and self.get_kicks(state, 2)
-                or self.knows_obscure(state) and self.has_plunge(state)
+                self.knows_obscure(state)
                 and (
-                    self.has_gem(state)
-                    or self.get_kicks(state, 2)),
+                    self.can_attack(state) and self.get_kicks(state, 2)
+                    or self.has_plunge(state) and self.has_gem(state)),
             "Underbelly Main Lower -> Underbelly Hole": lambda state:
                 self.has_plunge(state) and self.has_gem(state),
             "Underbelly Main Lower -> Underbelly By Heliacal": lambda state:
@@ -97,7 +96,7 @@ class PseudoregaliaHardRules(PseudoregaliaNormalRules):
                 self.has_breaker(state)
                 and (
                     state.has("Ascendant Light", self.player)
-                    or self.has_gem(state) and self.get_kicks(state, 1)
+                    or self.has_gem(state) and self.kick_or_plunge(state, 1)
                     or self.kick_or_plunge(state, 4)
                     or self.knows_obscure(state) and self.has_gem(state)),
             "Underbelly => Bailey -> Bailey Upper": lambda state:

--- a/AP_Randomizer/apworld/rules_hard.py
+++ b/AP_Randomizer/apworld/rules_hard.py
@@ -72,43 +72,44 @@ class PseudoregaliaHardRules(PseudoregaliaNormalRules):
                     or self.get_kicks(state, 1) and self.knows_obscure(state))
                 or self.has_breaker(state) and self.has_plunge(state) and self.get_kicks(state, 4)
                 or self.can_bounce(state) and self.get_kicks(state, 3),
-            "Underbelly => Dungeon -> Underbelly Ascendant Light": lambda state:
-                self.kick_or_plunge(state, 2),
-            "Underbelly Light Pillar -> Underbelly => Dungeon": lambda state:
-                self.has_plunge(state) and self.get_kicks(state, 2),
             "Underbelly Light Pillar -> Underbelly Ascendant Light": lambda state:
-                self.has_breaker(state) and self.get_kicks(state, 3)
+                self.has_breaker(state) and self.get_kicks(state, 2)
                 or self.knows_obscure(state) and self.has_plunge(state)
                 and (
                     self.has_gem(state)
-                    or self.get_kicks(state, 1)
-                    or self.can_slidejump(state)),
-            "Underbelly Ascendant Light -> Underbelly => Dungeon": lambda state:
-                self.kick_or_plunge(state, 2),
+                    or self.get_kicks(state, 2)),
             "Underbelly Main Lower -> Underbelly Hole": lambda state:
                 self.has_plunge(state) and self.has_gem(state),
             "Underbelly Main Lower -> Underbelly By Heliacal": lambda state:
-                self.has_slide(state) and self.knows_obscure(state) and self.get_kicks(state, 2),
+                self.has_slide(state) and self.get_kicks(state, 2),
             "Underbelly Main Lower -> Underbelly Main Upper": lambda state:
-                self.knows_obscure(state) and self.has_gem(state) and self.get_kicks(state, 1),
-            "Underbelly Main Upper -> Underbelly Light Pillar": lambda state:
-                self.has_gem(state)
+                self.knows_obscure(state)
                 and (
-                    self.has_plunge(state)
-                    or self.get_kicks(state, 3)),
+                    self.has_plunge(state) and self.get_kicks(state, 1)
+                    or self.has_plunge(state) and self.has_gem(state)
+                    or self.get_kicks(state, 2) and self.has_gem(state)),
+            "Underbelly Main Upper -> Underbelly Light Pillar": lambda state:
+                self.knows_obscure(state)
+                and (
+                    self.has_breaker(state) and self.has_gem(state)
+                    or self.can_slidejump(state) and self.get_kicks(state, 1) and self.has_plunge(state)),
             "Underbelly Main Upper -> Underbelly By Heliacal": lambda state:
                 self.has_breaker(state)
                 and (
-                    self.has_gem(state)
-                    or self.has_plunge(state) and self.get_kicks(state, 3)
-                    or self.can_slidejump(state) and self.get_kicks(state, 3)),
+                    state.has("Ascendant Light", self.player)
+                    or self.has_gem(state) and self.get_kicks(state, 1)
+                    or self.kick_or_plunge(state, 4)
+                    or self.knows_obscure(state) and self.has_gem(state)),
             "Underbelly Little Guy -> Bailey Upper": lambda state:
                 self.get_kicks(state, 3)
                 or self.can_slidejump(state) and self.get_kicks(state, 1),
-            "Underbelly Little Guy -> Underbelly Main Lower": lambda state: True,
+            "Underbelly Little Guy -> Underbelly Main Lower": lambda state: 
+                self.has_gem(state),
             "Underbelly Hole -> Underbelly Main Lower": lambda state:
-                self.get_kicks(state, 1)
-                or self.has_gem(state),
+                self.has_plunge(state)
+                and (
+                    self.get_kicks(state, 1)
+                    or self.has_gem(state)),
         }
 
         location_clauses = {
@@ -200,11 +201,10 @@ class PseudoregaliaHardRules(PseudoregaliaNormalRules):
             "The Underbelly - Strikebreak Wall": lambda state:
                 self.can_strikebreak(state)
                 and (
-                    self.get_kicks(state, 3)
-                    or self.get_kicks(state, 1) and self.has_plunge(state)),
+                    self.can_bounce(state)
+                    or self.kick_or_plunge(state, 3)),
             "The Underbelly - Surrounded By Holes": lambda state:
-                self.can_soulcutter(state) and self.get_kicks(state, 1)
-                or self.has_gem(state),
+                self.has_plunge(state) and self.has_gem(state),
         }
 
         self.apply_clauses(region_clauses, location_clauses)

--- a/AP_Randomizer/apworld/rules_hard.py
+++ b/AP_Randomizer/apworld/rules_hard.py
@@ -100,10 +100,10 @@ class PseudoregaliaHardRules(PseudoregaliaNormalRules):
                     or self.has_gem(state) and self.get_kicks(state, 1)
                     or self.kick_or_plunge(state, 4)
                     or self.knows_obscure(state) and self.has_gem(state)),
-            "Underbelly Little Guy -> Bailey Upper": lambda state:
+            "Underbelly => Bailey -> Bailey Upper": lambda state:
                 self.get_kicks(state, 3)
                 or self.can_slidejump(state) and self.get_kicks(state, 1),
-            "Underbelly Little Guy -> Underbelly Main Lower": lambda state: 
+            "Underbelly => Bailey -> Underbelly Main Lower": lambda state: 
                 self.has_gem(state),
             "Underbelly Hole -> Underbelly Main Lower": lambda state:
                 self.has_plunge(state)

--- a/AP_Randomizer/apworld/rules_lunatic.py
+++ b/AP_Randomizer/apworld/rules_lunatic.py
@@ -33,12 +33,7 @@ class PseudoregaliaLunaticRules(PseudoregaliaExpertRules):
                     and self.has_plunge(state)
                     and self.can_soulcutter(state)),
             "Underbelly Main Lower -> Underbelly Main Upper": lambda state:
-                self.has_slide(state)
-                and (
-                    self.has_gem(state)
-                    or self.get_kicks(state, 2)
-                    or self.get_kicks(state, 1) and self.has_plunge(state)
-                    or self.get_kicks(state, 1) and self.has_breaker(state)),
+                self.get_kicks(state, 1),
         }
 
         location_clauses = {

--- a/AP_Randomizer/apworld/rules_normal.py
+++ b/AP_Randomizer/apworld/rules_normal.py
@@ -196,7 +196,7 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 self.has_breaker(state)
                 and (
                     self.has_plunge(state)
-                    or self.get_kicks(state, 3)),
+                    or self.knows_obscure(state) and self.get_kicks(state, 3)),
             "Underbelly Ascendant Light -> Underbelly => Dungeon": lambda state:
                 self.can_bounce(state)
                 or self.has_gem(state)

--- a/AP_Randomizer/apworld/rules_normal.py
+++ b/AP_Randomizer/apworld/rules_normal.py
@@ -190,13 +190,13 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 self.can_bounce(state)
                 or self.kick_or_plunge(state, 4),
             "Underbelly Light Pillar -> Underbelly Ascendant Light": lambda state:
+                # this route is more difficult with ascendant light because of the long room with the switches, but
+                # since it's possible to use AL to go up the pillar and get to the item that way (i.e. passing through
+                # Underbelly => Dungeon), the logic for this entrance is written assuming the player doesn't have AL
                 self.has_breaker(state)
                 and (
                     self.has_plunge(state)
-                    or self.get_kicks(state, 4))
-                or self.knows_obscure(state) and self.has_plunge(state) and self.get_kicks(state, 1),
-            "Underbelly Ascendant Light -> Underbelly Light Pillar": lambda state:
-                self.has_breaker(state),
+                    or self.get_kicks(state, 3)),
             "Underbelly Ascendant Light -> Underbelly => Dungeon": lambda state:
                 self.can_bounce(state)
                 or self.has_gem(state)
@@ -212,22 +212,18 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
             "Underbelly Main Lower -> Underbelly By Heliacal": lambda state:
                 self.has_slide(state) and self.has_plunge(state),
             "Underbelly Main Lower -> Underbelly Main Upper": lambda state:
-                self.has_plunge(state)
-                and (
-                    self.get_kicks(state, 2)
-                    or self.get_kicks(state, 1) and self.has_gem(state)),
+                self.knows_obscure(state) and self.has_plunge(state) and self.get_kicks(state, 2),
             # "Underbelly Main Upper -> Underbelly Main Lower": lambda state: True,
             "Underbelly Main Upper -> Underbelly Light Pillar": lambda state:
                 self.has_breaker(state) and self.has_plunge(state)
-                or self.has_breaker(state) and self.get_kicks(state, 2)
-                or self.has_gem(state)
+                or self.knows_obscure(state) and self.has_breaker(state)
                 and (
-                    self.get_kicks(state, 2) and self.has_plunge(state)
-                    or self.get_kicks(state, 4)),
+                    self.get_kicks(state, 2)
+                    or self.has_gem(state) and self.get_kicks(state, 1)),
             "Underbelly Main Upper -> Underbelly By Heliacal": lambda state:
                 self.has_breaker(state)
                 and (
-                    state.has("Ascendant Light", self.player)
+                    state.has("Ascendant Light", self.player) and self.get_kicks(state, 1)
                     or self.can_slidejump(state) and self.get_kicks(state, 3)
                     or self.has_gem(state) and self.get_kicks(state, 2)),
             "Underbelly By Heliacal -> Underbelly Main Upper": lambda state:
@@ -241,17 +237,20 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 self.knows_obscure(state)
                 or self.has_plunge(state) and self.get_kicks(state, 1),
             "Underbelly Little Guy -> Underbelly Main Lower": lambda state:
-                self.has_gem(state)
-                or self.kick_or_plunge(state, 1),
+                self.has_plunge(state)
+                or self.get_kicks(state, 2)
+                or self.knows_obscure(state),
             # "Underbelly => Keep -> Keep => Underbelly": lambda state: True,
             "Underbelly => Keep -> Underbelly Hole": lambda state:
                 self.has_plunge(state),
             "Underbelly Hole -> Underbelly Main Lower": lambda state:
-                self.get_kicks(state, 2)
-                or self.has_gem(state) and self.can_slidejump(state)
-                or self.can_attack(state),
+                self.has_plunge(state)
+                and (
+                    self.can_attack(state)
+                    or self.can_slidejump(state) and self.has_gem(state)
+                    or self.can_slidejump(state) and self.get_kicks(state, 1)),
             "Underbelly Hole -> Underbelly => Keep": lambda state:
-                self.has_slide(state),
+                self.has_plunge(state) and self.has_slide(state),
         }
 
         location_clauses = {
@@ -419,9 +418,11 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 self.has_small_keys(state),
             "The Underbelly - Main Room": lambda state:
                 self.has_plunge(state)
-                or self.has_gem(state)
-                or self.get_kicks(state, 2)
-                or self.can_slidejump(state) and self.get_kicks(state, 1),
+                or self.can_slidejump(state) and self.get_kicks(state, 1)
+                or self.knows_obscure(state)
+                and (
+                    self.has_gem(state)
+                    or self.get_kicks(state, 2)),
             "The Underbelly - Alcove Near Light": lambda state:
                 self.can_attack(state)
                 or self.has_gem(state)
@@ -431,17 +432,13 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 self.has_plunge(state)
                 or self.get_kicks(state, 3),
             "The Underbelly - Strikebreak Wall": lambda state:
-                self.can_strikebreak(state)
-                and (
-                    self.can_bounce(state)
-                    or self.get_kicks(state, 4)
-                    or self.get_kicks(state, 2) and self.has_plunge(state)),
+                self.can_strikebreak(state) and self.can_bounce(state) and self.kick_or_plunge(state, 1),
             "The Underbelly - Surrounded By Holes": lambda state:
-                self.can_soulcutter(state)
+                self.can_soulcutter(state) and self.has_plunge(state)
                 and (
                     self.can_bounce(state)
-                    or self.get_kicks(state, 2))
-                or self.can_slidejump(state) and self.has_gem(state) and self.get_kicks(state, 1),
+                    or self.get_kicks(state, 2)
+                    or self.knows_obscure(state) and self.get_kicks(state, 1)),
 
             # TODO (time-trials): finish logic
             "Dilapidated Dungeon - Time Trial": lambda state:

--- a/AP_Randomizer/apworld/rules_normal.py
+++ b/AP_Randomizer/apworld/rules_normal.py
@@ -20,7 +20,7 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                     # get onto the bridge
                     self.can_slidejump(state)
                     or self.has_plunge(state) and self.knows_obscure(state)),
-            "Bailey Upper -> Underbelly Little Guy": lambda state:
+            "Bailey Upper -> Underbelly => Bailey": lambda state:
                 self.has_plunge(state),
             "Tower Remains -> The Great Door": lambda state:
                 self.can_attack(state) and self.has_gem(state) and self.kick_or_plunge(state, 1),
@@ -202,7 +202,7 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 or self.has_gem(state)
                 or self.get_kicks(state, 2)
                 or self.get_kicks(state, 1) and self.can_slidejump(state),
-            # "Underbelly Main Lower -> Underbelly Little Guy": lambda state: True,
+            # "Underbelly Main Lower -> Underbelly => Bailey": lambda state: True,
             "Underbelly Main Lower -> Underbelly Hole": lambda state:
                 self.has_plunge(state)
                 and (
@@ -232,11 +232,11 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 and (
                     self.get_kicks(state, 1)
                     or self.has_gem(state)),
-            # "Underbelly Little Guy -> Bailey Lower": lambda state: True,
-            "Underbelly Little Guy -> Bailey Upper": lambda state:
+            # "Underbelly => Bailey -> Bailey Lower": lambda state: True,
+            "Underbelly => Bailey -> Bailey Upper": lambda state:
                 self.knows_obscure(state)
                 or self.has_plunge(state) and self.get_kicks(state, 1),
-            "Underbelly Little Guy -> Underbelly Main Lower": lambda state:
+            "Underbelly => Bailey -> Underbelly Main Lower": lambda state:
                 self.has_plunge(state)
                 or self.get_kicks(state, 2)
                 or self.knows_obscure(state),


### PR DESCRIPTION
I made way too many notes about every rule changed in this PR, which you can find [here](https://docs.google.com/document/d/17tlsnXqWB5nDznDg6Yk-n48tcF3aJXjJIXvYQcDMm5w/edit?usp=sharing) if you need an explanation on any change. Only the rules that I changed are listed in the doc, so if a rule wasn't changed, I thought it looked good but I don't give my reasoning for it.

For access rules that start in Underbelly Hole, I made it explicit where plunge is needed. I think this is good for 2 reasons:
1. The current logic could be confusing to someone who doesn't have the context that plunge is excluded because it is needed to enter the region. It makes the rules more simple if they can be understood in isolation.
2. Even with that context, excluding it is still confusing because it obscures the intention of the rules. Meaning you can't tell if plunge is needed but excluded because it is assumed, or just unneeded.

I realized that the region renaming can be simplified by just changing Underbelly Little Guy to Underbelly => Bailey. For some reason, I was stuck on needing a Little Guy region, but Main Upper and Main Lower are fine as they are. If you don't like the renaming tho, it's easy enough to revert.