### PR TITLE
various logic additions/fixes

### DIFF
--- a/AP_Randomizer/apworld/rules_expert.py
+++ b/AP_Randomizer/apworld/rules_expert.py
@@ -176,7 +176,8 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
                 self.has_slide(state) and self.get_kicks(state, 1),
             "Dilapidated Dungeon - Rafters": lambda state:
                 self.kick_or_plunge(state, 2)
-                or self.can_gold_ultra(state) and self.kick_or_plunge(state, 1),
+                or self.can_gold_ultra(state) and self.kick_or_plunge(state, 1)
+                or self.can_bounce(state) and self.get_clings(state, 2),
             "Castle Sansa - Floater In Courtyard": lambda state:
                 self.can_bounce(state) and self.has_slide(state)
                 or self.can_gold_ultra(state) and self.get_kicks(state, 1)

--- a/AP_Randomizer/apworld/rules_expert.py
+++ b/AP_Randomizer/apworld/rules_expert.py
@@ -21,9 +21,11 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
             "Theatre Main -> Castle => Theatre (Front)": lambda state:
                 self.has_slide(state),
             "Theatre Pillar => Bailey -> Theatre Pillar": lambda state:
-                self.has_slide(state),
+                self.has_slide(state)
+                or self.get_clings(state, 2),
             "Castle => Theatre Pillar -> Theatre Pillar": lambda state:
                 self.get_kicks(state, 1)
+                or self.get_clings(state, 2)
                 or self.has_slide(state),
             "Theatre Pillar -> Theatre Main": lambda state:
                 self.has_slide(state) and self.kick_or_plunge(state, 3),
@@ -76,7 +78,7 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
                 and (
                     self.get_clings(state, 4)
                     or self.get_clings(state, 2) and self.get_kicks(state, 1)
-                    or self.get_clings(state, 2) and self.can_bounce(state)
+                    or self.get_clings(state, 2) and self.has_slide(state)
                     or self.can_bounce(state) and self.kick_or_plunge(state, 3)
                     or self.has_slide(state) and self.get_kicks(state, 3)),
             "Keep Main -> Keep => Underbelly": lambda state:
@@ -144,7 +146,8 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
             "Twilight Theatre - Soul Cutter": lambda state:
                 self.can_strikebreak(state) and self.has_slide(state),
             "Twilight Theatre - Corner Beam": lambda state:
-                self.has_slide(state)
+                self.get_kicks(state, 3)
+                or self.has_slide(state)
                 and (
                     self.kick_or_plunge(state, 2)
                     or self.get_clings(state, 2)),
@@ -169,9 +172,10 @@ class PseudoregaliaExpertRules(PseudoregaliaHardRules):
                 and (
                     self.can_bounce(state)
                     or self.get_kicks(state, 2)),
+            "Dilapidated Dungeon - Past Poles": lambda state:
+                self.has_slide(state) and self.get_kicks(state, 1),
             "Dilapidated Dungeon - Rafters": lambda state:
                 self.kick_or_plunge(state, 2)
-                or self.can_bounce(state) and self.get_kicks(state, 1)
                 or self.can_gold_ultra(state) and self.kick_or_plunge(state, 1),
             "Castle Sansa - Floater In Courtyard": lambda state:
                 self.can_bounce(state) and self.has_slide(state)

--- a/AP_Randomizer/apworld/rules_hard.py
+++ b/AP_Randomizer/apworld/rules_hard.py
@@ -76,6 +76,8 @@ class PseudoregaliaHardRules(PseudoregaliaNormalRules):
                 or self.can_bounce(state) and self.get_kicks(state, 3),
             "Keep Main -> Keep (Northeast) => Castle": lambda state:
                 self.get_kicks(state, 1),
+            "Underbelly => Dungeon -> Underbelly Ascendant Light": lambda state:
+                self.get_clings(state, 2),
             "Underbelly Light Pillar -> Underbelly Ascendant Light": lambda state:
                 self.knows_obscure(state)
                 and (
@@ -117,7 +119,10 @@ class PseudoregaliaHardRules(PseudoregaliaNormalRules):
 
         location_clauses = {
             "Empty Bailey - Cheese Bell": lambda state:
-                self.get_clings(state, 6),
+                self.get_kicks(state, 3)
+                or self.get_clings(state, 6),
+            "Empty Bailey - Center Steeple": lambda state:
+                self.get_kicks(state, 2) and self.has_breaker(state),
             "Twilight Theatre - Soul Cutter": lambda state:
                 self.can_strikebreak(state) and self.can_slidejump(state),
             "Twilight Theatre - Corner Beam": lambda state:
@@ -155,7 +160,8 @@ class PseudoregaliaHardRules(PseudoregaliaNormalRules):
                 or self.get_kicks(state, 3) and self.has_plunge(state),
             "Dilapidated Dungeon - Past Poles": lambda state:
                 self.get_clings(state, 2)
-                or self.get_kicks(state, 2),
+                or self.get_kicks(state, 2)
+                or self.knows_obscure(state) and self.can_slidejump(state) and self.get_kicks(state, 1),
             "Dilapidated Dungeon - Rafters": lambda state:
                 self.get_clings(state, 6)
                 or self.get_kicks(state, 1) and self.has_plunge(state)

--- a/AP_Randomizer/apworld/rules_lunatic.py
+++ b/AP_Randomizer/apworld/rules_lunatic.py
@@ -45,10 +45,10 @@ class PseudoregaliaLunaticRules(PseudoregaliaExpertRules):
             # "Twilight Theatre - Center Stage": lambda state:
             #     TODO: theoretical logic for soulcutterless or gemless
             "Dilapidated Dungeon - Past Poles": lambda state:
-                self.has_slide(state) and self.get_kicks(state, 1) and self.has_plunge(state),
+                self.get_kicks(state, 1) and self.has_plunge(state)
+                or self.has_breaker(state) and self.has_plunge(state) and self.has_slide(state),
             "Dilapidated Dungeon - Rafters": lambda state:
-                self.can_bounce(state) and self.kick_or_plunge(state, 1)
-                or self.can_gold_ultra(state),
+                self.can_gold_ultra(state),
             "Castle Sansa - Floater In Courtyard": lambda state:
                 self.has_slide(state) and self.get_kicks(state, 1),
             "Castle Sansa - Platform In Main Halls": lambda state:
@@ -57,7 +57,8 @@ class PseudoregaliaLunaticRules(PseudoregaliaExpertRules):
                 self.can_gold_slide_ultra(state) and self.get_kicks(state, 1)
                 or self.has_slide(state) and self.get_kicks(state, 1) and self.has_plunge(state),
             "Castle Sansa - Near Theatre Front": lambda state:
-                self.has_slide(state),
+                self.has_slide(state)
+                or self.get_clings(state, 2),
             "Sansa Keep - Levers Room": lambda state: True,
             "Listless Library - Upper Back": lambda state:
                 self.has_plunge(state),

--- a/AP_Randomizer/apworld/rules_normal.py
+++ b/AP_Randomizer/apworld/rules_normal.py
@@ -193,7 +193,7 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
             # "Underbelly => Dungeon -> Underbelly Light Pillar": lambda state: True,
             "Underbelly => Dungeon -> Underbelly Ascendant Light": lambda state:
                 self.can_bounce(state)
-                or self.get_clings(state, 2)
+                or self.get_clings(state, 2) and self.get_kicks(state, 1)
                 or self.get_kicks(state, 2)
                 or self.get_kicks(state, 1) and self.can_slidejump(state)
                 or self.knows_obscure(state) and self.can_attack(state),
@@ -269,12 +269,13 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
             "Empty Bailey - Solar Wind": lambda state:
                 self.has_slide(state),  # to consider: damage boosting w/ crouch
             "Empty Bailey - Cheese Bell": lambda state:  # TODO consider to/from center steeple
-                self.get_kicks(state, 3)
+                self.get_kicks(state, 4)
                 or self.get_clings(state, 2) and self.kick_or_plunge(state, 2),
             "Empty Bailey - Inside Building": lambda state:
                 self.has_slide(state),
             "Empty Bailey - Center Steeple": lambda state:
-                self.has_plunge(state),
+                self.has_plunge(state)
+                or self.get_kicks(state, 4),
             "Empty Bailey - Guarded Hand": lambda state:
                 upper_bailey.can_reach(state)
                 and (
@@ -329,10 +330,14 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 or self.can_slidejump(state) and self.get_kicks(state, 1) and self.can_bounce(state),
             "Dilapidated Dungeon - Past Poles": lambda state:
                 self.get_clings(state, 2) and self.kick_or_plunge(state, 1)
-                or self.get_kicks(state, 3),
+                or self.get_kicks(state, 3)
+                or self.knows_obscure(state) and self.can_slidejump(state) and self.get_kicks(state, 2),
             "Dilapidated Dungeon - Rafters": lambda state:
                 self.kick_or_plunge(state, 3)
-                or self.knows_obscure(state) and self.can_bounce(state) and self.get_clings(state, 2),
+                or self.knows_obscure(state) and self.can_bounce(state)
+                and (
+                    self.get_clings(state, 2)
+                    or self.has_plunge(state)),
             # "Castle Sansa - Indignation": lambda state: True,
             "Castle Sansa - Alcove Near Dungeon": lambda state:
                 self.get_clings(state, 2)

--- a/AP_Randomizer/apworld/rules_normal.py
+++ b/AP_Randomizer/apworld/rules_normal.py
@@ -334,10 +334,7 @@ class PseudoregaliaNormalRules(PseudoregaliaRulesHelpers):
                 or self.knows_obscure(state) and self.can_slidejump(state) and self.get_kicks(state, 2),
             "Dilapidated Dungeon - Rafters": lambda state:
                 self.kick_or_plunge(state, 3)
-                or self.knows_obscure(state) and self.can_bounce(state)
-                and (
-                    self.get_clings(state, 2)
-                    or self.has_plunge(state)),
+                or self.knows_obscure(state) and self.can_bounce(state) and self.has_plunge(state),
             # "Castle Sansa - Indignation": lambda state: True,
             "Castle Sansa - Alcove Near Dungeon": lambda state:
                 self.get_clings(state, 2)


### PR DESCRIPTION
`Underbelly => Dungeon -> Underbelly Ascendant Light`
* added `1kick` to the `2cling` route in normal because getting from the top of the pillar to the lower door requires a kinda tricky jump that just cling doesn't really help with
* added `2cling` to hard since the jump should be fine at hard difficulty

`Empty Bailey - Cheese Bell`
* swapped `3kick` for `4kick` in normal and moved `3kick` to hard, and I'm citing [this](https://discord.com/channels/731205301247803413/1147564210436452393/1393004986987970653) as my evidence

`Empty Bailey - Center Steeple`
* added `4kick` to normal and `2kick + breaker` to hard for some kick only routes at lower difficulties. [this](https://discord.com/channels/731205301247803413/1147564210436452393/1397212264213381262) was the motivation for looking into this one

`Dilapidated Dungeon - Past Poles`
* logic takes into account that you can stand on the lip in front of the gate to get from the first to the second pole (s/o Lizzy). it's pretty easy to do even with no items. this accounts for adding `obscure + slidejump + 2kick` on normal, `obscure + slidejump + 1kick` on hard, and `slide + 1kick` on expert
* for the lunatic changes, I discovered recently that you can get to the first pole with a crouch backflip + sunsetter flip and a really late kick, which means `1kick + plunge` is possible without slide. and I posted a video on how to get from the second pole to the item with just breaker + plunge, which accounts for the `breaker + plunge + slide` route

`Dilapidated Dungeon - Rafters`
* found out recently that you can do a crouch backflip + sunsetter flip from the top of the door to get up to the rafters pretty easily (s/o sherbert). previously I thought you needed either a really tricky jump + sunsetter flip or first person abuse (which I've generally thought of as lunatic only). so I moved `bounce + plunge` from lunatic to obscure
* as a bit of clean up, removed `bounce + 1kick` from expert since that was already in hard

`Theatre Pillar => Bailey -> Theatre Pillar`
* added `2cling` to expert, which abuses the fact that jumping out of cling gives a decent amount of speed (800 as opposed to the normal walking speed of 550). you can use this to get enough speed to reach the first bubble. the rest of the way is pretty easy with gainers and cling

`Castle => Theatre Pillar -> Theatre Pillar`
* added `2cling` to expert. same tech as above, except you use it here to gain some speed to do a high gainer to reach one of the early platforms off the pillar. again once you get there, the rest of the way is really easy

`Keep Main -> Keep Throne Room`
* swapped out `2cling + bounce` for `2cling + slide` on expert. `2cling + bounce` required getting on top of a door near the end with just `2cling`, which is kinda annoying and maybe lunatic only so I removed it. but `2cling + slide` is fairly easy and wasn't accounted for before

`Twilight Theatre - Corner Beam`
* added `3kick` to expert which wasn't accounted for before. it isn't too bad and could maybe be in hard, but I put it in expert to be safe

`Castle Sansa - Near Theatre Front`
* added `2cling` to lunatic. requires getting on the door frame with `2cling` which I discovered was possible when originally doing split cling but just never put it in logic