### PR TITLE
fix crash on reconnect

### DIFF
--- a/AP_Randomizer/src/Client.cpp
+++ b/AP_Randomizer/src/Client.cpp
@@ -65,6 +65,7 @@ namespace Client {
         if (ap != nullptr) {
             delete ap;
         }
+        ap = nullptr;
         GameData::Initialize();
         ap = new APClient(uuid, game_name, uri, cert_store);
         connection_retries = 0;


### PR DESCRIPTION
Changes

* Fixed a bug that could cause a crash when executing the `/connect` command during an active connection (for example, when trying to connect again after inputting incorrect connect information)